### PR TITLE
Clone instance

### DIFF
--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -1494,6 +1494,9 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
         $resourceInfo.popover({ trigger: "click hover" });
         $resourcedivheading.append($resourceInfo);
       }
+      if (rt.id.match(/Instance$/i)) {
+        $resourcedivheading.append('<button type="button" class="pull-right btn btn-primary"><span class="glyphicon glyphicon-duplicate"></span> Clone Instance</button>');
+      }
       $resourcediv.append($resourcedivheading);
 
       var $formgroup = $('<div>', {

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -1486,12 +1486,14 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       }); // is data-uri used?
       
       var $resourcedivheading = $('<h4>' + rt.resourceLabel + ' </h4>');
-      var $resourceInfo = $('<a><span class="glyphicon glyphicon-info-sign"></span></a>');
-      $resourceInfo.attr('data-content',rt.defaulturi);
-      $resourceInfo.attr('data-toggle','popover');
-      $resourceInfo.attr('title','Resource ID');
-      $resourceInfo.popover({ trigger: "click hover" });
-      $resourcedivheading.append($resourceInfo);
+      if (rt.defaulturi.match(/^http/)) {
+        var $resourceInfo = $('<a><span class="glyphicon glyphicon-info-sign"></span></a>');
+        $resourceInfo.attr('data-content', rt.defaulturi);
+        $resourceInfo.attr('data-toggle','popover');
+        $resourceInfo.attr('title','Resource ID');
+        $resourceInfo.popover({ trigger: "click hover" });
+        $resourcedivheading.append($resourceInfo);
+      }
       $resourcediv.append($resourcedivheading);
 
       var $formgroup = $('<div>', {

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -1494,9 +1494,12 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
         $resourceInfo.popover({ trigger: "click hover" });
         $resourcedivheading.append($resourceInfo);
       }
+    
+      var $clonebutton = $('<button id="clone-instance" type="button" class="pull-right btn btn-primary"><span class="glyphicon glyphicon-duplicate"></span> Clone Instance</button>');
       if (rt.id.match(/Instance$/i)) {
-        $resourcedivheading.append('<button type="button" class="pull-right btn btn-primary"><span class="glyphicon glyphicon-duplicate"></span> Clone Instance</button>');
+        $resourcedivheading.append($clonebutton);
       }
+      
       $resourcediv.append($resourcedivheading);
 
       var $formgroup = $('<div>', {

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -1487,8 +1487,9 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       
       var $resourcedivheading = $('<h4>' + rt.resourceLabel + ' </h4>');
       if (rt.defaulturi.match(/^http/)) {
+        var rid = rt.defaulturi;
         var $resourceInfo = $('<a><span class="glyphicon glyphicon-info-sign"></span></a>');
-        $resourceInfo.attr('data-content', rt.defaulturi);
+        $resourceInfo.attr('data-content', rid);
         $resourceInfo.attr('data-toggle','popover');
         $resourceInfo.attr('title','Resource ID');
         $resourceInfo.popover({ trigger: "click hover" });
@@ -1499,8 +1500,17 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       if (rt.id.match(/Instance$/i)) {
         $resourcedivheading.append($clonebutton);
       }
-      
+
       $resourcediv.append($resourcedivheading);
+
+      $clonebutton.click(function() {
+        var oldguid = bfeditor.bfestore.name;
+        bfeditor.bfestore.name = guid();
+        $resourceInfo.attr('data-content', 'Clone of ' + rt.defaulturi);
+        if (oldguid != bfeditor.bfestore.name) {
+          alert('Clone successfully created.')
+        }
+      });
 
       var $formgroup = $('<div>', {
         class: 'form-group row'

--- a/static/js/config-dev.js
+++ b/static/js/config-dev.js
@@ -224,16 +224,19 @@ function deleteId(id, csrf, bfelog){
  * itself. The "versoURL" variable is a convenience for setting the
  * base URL of verso in the "config" definition below.
  */
+var rectoBase = "http://mlvlp04.loc.gov:3000";
 
-var versoURL = "http://mlvlp04.loc.gov:3000/verso/api";
-//var versoURL = "/verso/api";
+// The following line is for local developement
+// rectoBase = "http://localhost:3000";
+
+var versoURL = rectoBase + "/verso/api";
+
 var config = {
   /*            "logging": {
                 "level": "DEBUG",
                 "toConsole": true
                 },*/
-  "url" : "http://mlvlp04.loc.gov:3000",
-  // "url" : "http://localhost:3000",
+  "url" : rectoBase,
   "baseURI": "http://id.loc.gov/",
   "basedbURI": "http://mlvlp04.loc.gov:8230",
   "resourceURI": "http://mlvlp04.loc.gov:8230/resources",


### PR DESCRIPTION
Ok-- I have a pretty ugly clone function happening.  It actually saves a new instance record to the local db (verso).  

The "clone instance" button only shows up for instance records and it ls located to the far right of the "BIBFRAME Instance (RDA Manifestation)" header.  When you click on it, a guid gets generated and saved to the bfestore.name field.  After you click preview, you can then save it (we may want this to all happen after clicking the "clone instance" button.)  Oh yeah, after a successful clone, the little information mouseover will display "Clone of <some resourceID>" (this happens before preview and save.)

I'm not sure if it does everything your looking for, this is why I'm adding this pull request.  I still need to add a better confirmation modal, etc.