### PR TITLE
Add field

### DIFF
--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -176,6 +176,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
   // var store = new rdfstore.Store();
   var profiles = [];
   var resourceTemplates = [];
+  var addFields = {};
   // var startingPoints = [];
   // var formTemplates = [];
   // var lookups = [];
@@ -301,6 +302,16 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
                 profiles.push(data[j].json);
                 for (var rt = 0; rt < data[j].json.Profile.resourceTemplates.length; rt++) {
                   resourceTemplates.push(data[j].json.Profile.resourceTemplates[rt]);
+                  // populate addFields hash with property templates for the "add property" function.
+                  data[j].json.Profile.resourceTemplates[rt].propertyTemplates.forEach(function(ptemp) {
+                    if (ptemp.type != 'resource') {
+                      if (ptemp.propertyLabel !== undefined) {
+                        var propKey = ptemp.propertyLabel;
+                        propKey = propKey.replace(/^\d\w*\. /,'');
+                        addFields[propKey] = ptemp;
+                      }
+                    }
+                  })
                 }
                 bfelog.addMsg(new Error(), 'INFO', 'Loaded profile: ' + data[j].name);
               }
@@ -1823,15 +1834,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
         $resourcediv.append($formgroup);
         forEachFirst = false;
       });
-      var addFields = {};
-      resourceTemplates.forEach(function(rtemp) {
-        rtemp.propertyTemplates.forEach(function(ptemp) {
-          if (ptemp.type != 'resource') {
-            addFields[ptemp.propertyURI] = ptemp;
-          }
-        })
-      });
-      console.log(addFields);
+      // starting the "add property" stuff here
       var substringMatcher = function(strs) {
         return function findMatches(q, cb) {
           var matches, substrRegex;

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -1823,19 +1823,27 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
         $resourcediv.append($formgroup);
         forEachFirst = false;
       });
-      
+      var addFields = {};
+      resourceTemplates.forEach(function(rtemp) {
+        rtemp.propertyTemplates.forEach(function(ptemp) {
+          if (ptemp.type != 'resource') {
+            addFields[ptemp.propertyURI] = ptemp;
+          }
+        })
+      });
+      console.log(addFields);
       var substringMatcher = function(strs) {
         return function findMatches(q, cb) {
           var matches, substrRegex;
           matches = [];
           substrRegex = new RegExp(q, 'i');
           $.each(strs, function(i, str) {
-            if (substrRegex.test(str.id)) {
-              console.log(str);
-              matches.push({value: str.id, key: i});
+            if (substrRegex.test(str.propertyLabel)) {
+              // console.log(str);
+              matches.push({value: str.propertyLabel, key: i});
             }
           });
-          // console.log(matches);
+          console.log(matches);
           cb(matches);
         };
       };
@@ -1848,16 +1856,14 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
         {
           name: 'resources',
           displayKey: 'value',
-          source: substringMatcher(resourceTemplates),
+          source: substringMatcher(addFields),
         }
       ).on('typeahead:selected', function (e, suggestion) {
-        var newproperties = resourceTemplates[suggestion.key].propertyTemplates;
-        console.log(newproperties);
-        newproperties.forEach(function(p) {
-          p.display = 'true';
-          p.guid = guid();
-          rt.propertyTemplates.push(p);
-        });
+        var newproperty = addFields[suggestion.key];
+        console.log(newproperty);
+        newproperty.display = 'true';
+        newproperty.guid = guid();
+        rt.propertyTemplates.push(newproperty);
         cbLoadTemplates(rt.propertyTemplates);       
       });
       $addproplabel = $('<label class="col-sm-3 control-label">Add Property</label>');

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -1249,11 +1249,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
               }
 
               save_json.rdf = bfeditor.bfestore.store2jsonldExpanded();
-              /* addedProperties.forEach(function(addprops) {
-                save_json.addedproperties
-              }); */
               save_json.addedproperties = addedProperties;
-              
 
               if (_.some(bfeditor.bfestore.store, {'p': 'http://id.loc.gov/ontologies/bibframe/mainTitle'})) {
                 editorconfig.save.callback(save_json, editorconfig.getCSRF.callback(), bfelog, function (save, save_name) {
@@ -1868,7 +1864,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
           };
         };
         $addpropdata = $('<div>', { class: 'col-sm-8' });
-        $addpropinput = $('<input>', { id: 'addproperty', type: 'text', class: 'form-control' });
+        $addpropinput = $('<input>', { id: 'addproperty', type: 'text', class: 'form-control', placeholder: 'Type for suggestions' });
         $addpropinput.appendTo($addpropdata).typeahead(
           {
             highlight: true,        

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -1843,10 +1843,10 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
           $.each(strs, function(i, str) {
             if (substrRegex.test(str.propertyLabel)) {
               // console.log(str);
-              matches.push({value: str.propertyLabel, key: i});
+              matches.push({value: i});
             }
           });
-          console.log(matches);
+          // console.log(matches);
           cb(matches);
         };
       };
@@ -1862,7 +1862,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
           source: substringMatcher(addFields),
         }
       ).on('typeahead:selected', function (e, suggestion) {
-        var newproperty = addFields[suggestion.key];
+        var newproperty = addFields[suggestion.value];
         console.log(newproperty);
         newproperty.display = 'true';
         newproperty.guid = guid();

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -1122,7 +1122,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       if (loadtemplates.length > 0) {
         bfelog.addMsg(new Error(), 'DEBUG', 'Loading selected template(s)', loadtemplates);
         var form = getForm(loadtemplates);
-        $('.typeahead', form.form).each(function () {
+        $('.typeahead:not(#add-property)', form.form).each(function () {
           setTypeahead(this);
         });
         var $exitButtonGroup = $('<div class="btn-group pull-right"> \
@@ -1833,12 +1833,28 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
             $formgroup.append($input);
             $formgroup.append($button);
             // $formgroup.append($saves);
-          }
+          }       
         }
-
+        
         $resourcediv.append($formgroup);
         forEachFirst = false;
       });
+
+      $addpropinput = $('<input>', { type: 'text', id: 'add-property', class: 'typeahead' });
+      $addpropinput.typeahead({
+        hint: true,
+        minLength: 1,
+        source: ['homer','marge','bart','lisa']
+      });
+
+      $addpropdata = $('<div>', { class: 'col-sm-8' });
+      $addpropdata.append($addpropinput);
+      $addproplabel = $('<label class="col-sm-3 control-label">Add Property</label>');
+      $addprop = $('<div>', { class: 'form-group row' });
+      $addprop.append($addproplabel);
+      $addprop.append($addpropdata);
+
+      $resourcediv.append($addprop);
       form.append($resourcediv);
     });
 

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -1627,6 +1627,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       $resourceinput.keyup(enterHandler);
       $resourceinput.append($saves);
       $resourcediv.append($formgroup);
+      var addPropsUsed = {};
 
       rt.propertyTemplates.forEach(function (property) {
         // Each property needs to be uniquely identified, separate from
@@ -1634,6 +1635,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
         var pguid = guid();
         property.guid = pguid;
         property.display = 'true';
+        addPropsUsed[property.propertyURI] = 1;
 
         var $formgroup = $('<div>', {
           class: 'form-group row'
@@ -1841,10 +1843,9 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
           matches = [];
           substrRegex = new RegExp(q, 'i');
           $.each(strs, function(i, str) {
-            if (substrRegex.test(str.propertyLabel)) {
-              // console.log(str);
-              matches.push({value: i});
-            }
+              if (substrRegex.test(str.propertyLabel) && !addPropsUsed[str.propertyURI]) {
+                matches.push({value: i});
+              }
           });
           // console.log(matches);
           cb(matches);

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -646,20 +646,6 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
               }
 
               var bTypes = [];
-              /* rowData.rdf.forEach(function(t){
-                            if(t["@type"] !== undefined && t["@type"].length > 0 && t["@id"].indexOf("_:b")){
-                                //console.log(t["@id"] + " " +t["@type"][0]);
-                                bTypes.push(t["@type"][0]);
-                            } else {
-                                //console.log();
-                            }
-                        });
-
-                        findRt = _.where(editorconfig.startingPoints, { menuItems:[{type:bTypes}] })
-                        if (findRt[0] !== undefined){
-                            spoints = _.where(editorconfig.startingPoints, { menuItems:[{type:bTypes}] })[0].menuItems[0];
-                        }
-              */
               var temptemplates = [];
               spoints.useResourceTemplates.forEach(function (l) {
                 var useguid = guid();
@@ -1421,7 +1407,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
 
     // Load up the requested templates, add seed data.
     for (var urt = 0; urt < loadTemplates.length; urt++) {
-      // console.log(loadTemplates[urt]);
+      console.log(loadTemplates[urt]);
       rt = _.where(resourceTemplates, {
         'id': loadTemplates[urt].resourceTemplateID
       });
@@ -1473,7 +1459,8 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
         bfelog.addMsg(new Error(), 'WARN', 'Unable to locate resourceTemplate. Verify the resourceTemplate ID is correct.');
       }
     }
-
+console.log('fobject');
+console.log(fobject);
     // Let's create the form
     var form = $('<form>', {
       id: 'bfeditor-form-' + fobject.id,
@@ -1626,37 +1613,9 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       };
 
       $resourceinput.keyup(enterHandler);
-      // $formgroup.append($label);
       $resourceinput.append($saves);
-      // $formgroup.append($resourceinput);
-      // $button.append($linkbutton);
-      // $formgroup.append($button);
       $resourcediv.append($formgroup);
-      console.log(resourceTemplates);
-      /* rt.propertyTemplates.push({
-        "mandatory": "false",
-        "repeatable": "true",
-        "type": "resource",
-        "resourceTemplates": [],
-        "valueConstraint": {
-          "valueTemplateRefs": [],
-          "useValuesFrom": [
-            "http://id.loc.gov/vocabulary/contentTypes"
-          ],
-          "valueDataType": {
-            "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
-          },
-          "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
-          "defaultLiteral": "text",
-          "editable": "false",
-          "repeatable": "true"
-        },
-        "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
-        "propertyLabel": "Add Field...",
-        "remark": "",
-        "guid": "b5b847d5-be28-4ee6-a9cc-8f3d4c4ba61c",
-        "display": "true"
-      }); */
+
       rt.propertyTemplates.forEach(function (property) {
         // Each property needs to be uniquely identified, separate from
         // the resourceTemplate.
@@ -1874,7 +1833,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
               matches.push({value: str.id, key: i});
             }
           });
-          console.log(matches);
+          // console.log(matches);
           cb(matches);
         };
       };
@@ -1891,7 +1850,15 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
           source: substringMatcher(resourceTemplates),
         }
       ).on('typeahead:selected', function (e, suggestion) {
-        console.log(resourceTemplates[suggestion.key]);
+        var newproperties = resourceTemplates[suggestion.key].propertyTemplates;
+        console.log(newproperties);
+        newproperties.forEach(function(p) {
+          p.display = 'true';
+          p.guid = guid();
+          rt.propertyTemplates.push(p);
+        });
+        console.log(rt);
+        getForm(bfeditor.bfestore.loadtemplates);
       });
       $addproplabel = $('<label class="col-sm-3 control-label">Add Property</label>');
       $addprop = $('<div>', { class: 'form-group row' });
@@ -1975,6 +1942,8 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
           rt.guid = rt.useguid;
         }
         rt.propertyTemplates.forEach(function (property) {
+          console.log('HEY');
+          console.log(property);
           if (_.has(property, 'valueConstraint')) {
             if (_.has(property.valueConstraint, 'valueTemplateRefs') && !_.isEmpty(property.valueConstraint.valueTemplateRefs)) {
               var vtRefs = property.valueConstraint.valueTemplateRefs;
@@ -3148,7 +3117,6 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       };
       dshash.displayKey = 'value';
       dshashes.push(dshash);
-      console.log(dshash);
     });
 
     bfelog.addMsg(new Error(), 'DEBUG', 'Data source hashes', dshashes);

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -177,6 +177,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
   var profiles = [];
   var resourceTemplates = [];
   var addFields = {};
+  var addedProperties = [];
   // var startingPoints = [];
   // var formTemplates = [];
   // var lookups = [];
@@ -671,6 +672,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
               });
 
               $(td).find('#bfeditor-retrieve' + rowData.id).click(function () {
+                addedProperties = [];
                 if (editorconfig.retrieve.callback !== undefined) {
                   // loadtemplates = temptemplates;
                   bfestore.loadtemplates = temptemplates;
@@ -1246,6 +1248,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
               }
 
               save_json.rdf = bfeditor.bfestore.store2jsonldExpanded();
+              save_json.addedproperties = addedProperties;
 
               if (_.some(bfeditor.bfestore.store, {'p': 'http://id.loc.gov/ontologies/bibframe/mainTitle'})) {
                 editorconfig.save.callback(save_json, editorconfig.getCSRF.callback(), bfelog, function (save, save_name) {
@@ -1366,7 +1369,8 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
     // store = new rdfstore.Store();
     var spnums = spid.replace('sp-', '').split('_');
     var spoints = editorconfig.startingPoints[spnums[0]].menuItems[spnums[1]];
-
+    addedProperties = [];
+    
     bfeditor.bfestore.store = [];
     bfeditor.bfestore.name = guid();
     bfeditor.bfestore.created = new Date().toUTCString();
@@ -1406,7 +1410,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
     */
   function getForm (loadTemplates, pt) {
     var rt, property;
-  
+
     // Create the form object.
     var fguid = guid();
     var fobject = {};
@@ -1480,6 +1484,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
     if (pt) {
       fobject.resourceTemplates[0].propertyTemplates = pt;
     }
+
     fobject.resourceTemplates.forEach(function (rt) {
       bfelog.addMsg(new Error(), 'DEBUG', 'Creating form for: ' + rt.id, rt);
       var $resourcediv = $('<div>', {
@@ -1869,6 +1874,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
           newproperty.display = 'true';
           newproperty.guid = guid();
           rt.propertyTemplates.push(newproperty);
+          addedProperties.push(newproperty);
           cbLoadTemplates(rt.propertyTemplates);       
         });
         $addproplabel = $('<label class="col-sm-3 control-label">Add Property</label>');
@@ -1953,8 +1959,6 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
           rt.guid = rt.useguid;
         }
         rt.propertyTemplates.forEach(function (property) {
-          console.log('HEY');
-          console.log(property);
           if (_.has(property, 'valueConstraint')) {
             if (_.has(property.valueConstraint, 'valueTemplateRefs') && !_.isEmpty(property.valueConstraint.valueTemplateRefs)) {
               var vtRefs = property.valueConstraint.valueTemplateRefs;

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -1837,45 +1837,46 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
         forEachFirst = false;
       });
       // starting the "add property" stuff here
-      var substringMatcher = function(strs) {
-        return function findMatches(q, cb) {
-          var matches, substrRegex;
-          matches = [];
-          substrRegex = new RegExp(q, 'i');
-          $.each(strs, function(i, str) {
-              if (substrRegex.test(str.propertyLabel) && !addPropsUsed[str.propertyURI]) {
-                matches.push({value: i});
-              }
-          });
-          // console.log(matches);
-          cb(matches);
+      if (rt.embedType == 'page') {
+        var substringMatcher = function(strs) {
+          return function findMatches(q, cb) {
+            var matches, substrRegex;
+            matches = [];
+            substrRegex = new RegExp(q, 'i');
+            $.each(strs, function(i, str) {
+                if (substrRegex.test(str.propertyLabel) && !addPropsUsed[str.propertyURI]) {
+                  matches.push({value: i});
+                }
+            });
+            // console.log(matches);
+            cb(matches);
+          };
         };
-      };
-      $addpropdata = $('<div>', { class: 'col-sm-8' });
-      $addpropinput = $('<input>', { id: 'addproperty', type: 'text', class: 'form-control' });
-      $addpropinput.appendTo($addpropdata).typeahead(
-        {
-          highlight: true,        
-        },
-        {
-          name: 'resources',
-          displayKey: 'value',
-          source: substringMatcher(addFields),
-        }
-      ).on('typeahead:selected', function (e, suggestion) {
-        var newproperty = addFields[suggestion.value];
-        console.log(newproperty);
-        newproperty.display = 'true';
-        newproperty.guid = guid();
-        rt.propertyTemplates.push(newproperty);
-        cbLoadTemplates(rt.propertyTemplates);       
-      });
-      $addproplabel = $('<label class="col-sm-3 control-label">Add Property</label>');
-      $addprop = $('<div>', { class: 'form-group row' });
-      $addprop.append($addproplabel);
-      $addprop.append($addpropdata);
-      $resourcediv.append($addprop);
-      $addpropinput
+        $addpropdata = $('<div>', { class: 'col-sm-8' });
+        $addpropinput = $('<input>', { id: 'addproperty', type: 'text', class: 'form-control' });
+        $addpropinput.appendTo($addpropdata).typeahead(
+          {
+            highlight: true,        
+          },
+          {
+            name: 'resources',
+            displayKey: 'value',
+            source: substringMatcher(addFields),
+          }
+        ).on('typeahead:selected', function (e, suggestion) {
+          var newproperty = addFields[suggestion.value];
+          console.log(newproperty);
+          newproperty.display = 'true';
+          newproperty.guid = guid();
+          rt.propertyTemplates.push(newproperty);
+          cbLoadTemplates(rt.propertyTemplates);       
+        });
+        $addproplabel = $('<label class="col-sm-3 control-label">Add Property</label>');
+        $addprop = $('<div>', { class: 'form-group row' });
+        $addprop.append($addproplabel);
+        $addprop.append($addpropdata);
+        $resourcediv.append($addprop);
+      }
       form.append($resourcediv);
     });
 

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -1122,7 +1122,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       if (loadtemplates.length > 0) {
         bfelog.addMsg(new Error(), 'DEBUG', 'Loading selected template(s)', loadtemplates);
         var form = getForm(loadtemplates);
-        $('.typeahead:not("#add-property")', form.form).each(function () {
+        $('.typeahead.form-control', form.form).each(function () {
           setTypeahead(this);
         });
         var $exitButtonGroup = $('<div class="btn-group pull-right"> \
@@ -1871,7 +1871,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
           substrRegex = new RegExp(q, 'i');
           $.each(strs, function(i, str) {
             if (substrRegex.test(str.id)) {
-              matches.push({value: str.id});
+              matches.push({value: str.id, key: i});
             }
           });
           console.log(matches);
@@ -1880,24 +1880,26 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       };
       
       $addpropdata = $('<div>', { class: 'col-sm-8' });
-      $('<input>', { id: 'add-property' }).appendTo($addpropdata).typeahead(
+      $addpropinput = $('<input>', { id: 'addproperty', type: 'text', class: 'typeahead', style: 'width: 100%' });
+      $addpropinput.appendTo($addpropdata).typeahead(
         {
-          highlight: true,
+          highlight: true,        
         },
         {
           name: 'resources',
           displayKey: 'value',
           source: substringMatcher(resourceTemplates),
-          limit: 5
         }
-      );
+      ).on('typeahead:selected', function (e, suggestion) {
+        console.log(resourceTemplates[suggestion.key]);
+      });
       $addproplabel = $('<label class="col-sm-3 control-label">Add Property</label>');
       $addprop = $('<div>', { class: 'form-group row' });
       $addprop.append($addproplabel);
       $addprop.append($addpropdata);
       $resourcediv.append($addprop);
+      $addpropinput
       form.append($resourcediv);
-      
     });
 
     // OK now we need to populate the form with data, if appropriate.
@@ -2750,7 +2752,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       $(this).empty();
     });
 
-    $('.typeahead', form.form).each(function () {
+    $('.typeahead.form-control', form.form).each(function () {
       setTypeahead(this);
     });
 

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -672,7 +672,6 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
               });
 
               $(td).find('#bfeditor-retrieve' + rowData.id).click(function () {
-                addedProperties = [];
                 if (editorconfig.retrieve.callback !== undefined) {
                   // loadtemplates = temptemplates;
                   bfestore.loadtemplates = temptemplates;
@@ -684,7 +683,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
                   bfestore.created = rowData.created;
                   bfestore.url = rowData.url;
                   bfestore.profile = rowData.profile;
-                  bfestore.addedproperties = rowData.addedproperties;
+                  addedProperties = rowData.addedproperties;
                   $('[href=#create]').tab('show');
                   if ($('#bfeditor-messagediv').length) {
                     $('#bfeditor-messagediv').remove();
@@ -696,6 +695,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
                   window.location.hash = mintResource(rowData.name);
                 } else {
                   // retrieve disabled
+                  addedProperties = [];
                 }
               });
 
@@ -1249,10 +1249,10 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
               }
 
               save_json.rdf = bfeditor.bfestore.store2jsonldExpanded();
-              addedProperties.forEach(function(addprops) {
-                bfeditor.bfestore.addedproperties.push(addprops);
-              });
-              save_json.addedproperties = bfeditor.bfestore.addedproperties;
+              /* addedProperties.forEach(function(addprops) {
+                save_json.addedproperties
+              }); */
+              save_json.addedproperties = addedProperties;
               
 
               if (_.some(bfeditor.bfestore.store, {'p': 'http://id.loc.gov/ontologies/bibframe/mainTitle'})) {
@@ -1638,12 +1638,12 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       $resourceinput.append($saves);
       $resourcediv.append($formgroup);
       var addPropsUsed = {};
-      if (bfeditor.bfestore.addedproperties !== undefined && rt.embedType == 'page' && !pt) {
-        bfeditor.bfestore.addedproperties.forEach(function(adata) {
+      if (addedProperties !== undefined && rt.embedType == 'page' && !pt) {
+        addedProperties.forEach(function(adata) {
           rt.propertyTemplates.push(adata);
         });
       }
-      console.log(rt);
+
       rt.propertyTemplates.forEach(function (property) {
         // Each property needs to be uniquely identified, separate from
         // the resourceTemplate.

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -1094,7 +1094,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
     }
   }
 
-  function cbLoadTemplates () {
+  function cbLoadTemplates (propTemps) {
     $('#bfeditor-loader').width($('#bfeditor-loader').width() + 5 + '%');
     loadtemplatesANDlookupsCounter++;
     var loadtemplates = bfeditor.bfestore.loadtemplates;
@@ -1107,7 +1107,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       $('#bfeditor-formdiv').html('');
       if (loadtemplates.length > 0) {
         bfelog.addMsg(new Error(), 'DEBUG', 'Loading selected template(s)', loadtemplates);
-        var form = getForm(loadtemplates);
+        var form = getForm(loadtemplates, propTemps);
         $('.typeahead', form.form).each(function () {
           setTypeahead(this);
         });
@@ -1393,9 +1393,9 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
             data=bfestore
         }
     */
-  function getForm (loadTemplates) {
+  function getForm (loadTemplates, pt) {
     var rt, property;
-
+  
     // Create the form object.
     var fguid = guid();
     var fobject = {};
@@ -1407,7 +1407,6 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
 
     // Load up the requested templates, add seed data.
     for (var urt = 0; urt < loadTemplates.length; urt++) {
-      console.log(loadTemplates[urt]);
       rt = _.where(resourceTemplates, {
         'id': loadTemplates[urt].resourceTemplateID
       });
@@ -1459,8 +1458,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
         bfelog.addMsg(new Error(), 'WARN', 'Unable to locate resourceTemplate. Verify the resourceTemplate ID is correct.');
       }
     }
-console.log('fobject');
-console.log(fobject);
+
     // Let's create the form
     var form = $('<form>', {
       id: 'bfeditor-form-' + fobject.id,
@@ -1468,6 +1466,9 @@ console.log(fobject);
       role: 'form'
     });
     var forEachFirst = true;
+    if (pt) {
+      fobject.resourceTemplates[0].propertyTemplates = pt;
+    }
     fobject.resourceTemplates.forEach(function (rt) {
       bfelog.addMsg(new Error(), 'DEBUG', 'Creating form for: ' + rt.id, rt);
       var $resourcediv = $('<div>', {
@@ -1830,6 +1831,7 @@ console.log(fobject);
           substrRegex = new RegExp(q, 'i');
           $.each(strs, function(i, str) {
             if (substrRegex.test(str.id)) {
+              console.log(str);
               matches.push({value: str.id, key: i});
             }
           });
@@ -1837,7 +1839,6 @@ console.log(fobject);
           cb(matches);
         };
       };
-      
       $addpropdata = $('<div>', { class: 'col-sm-8' });
       $addpropinput = $('<input>', { id: 'addproperty', type: 'text', class: 'form-control' });
       $addpropinput.appendTo($addpropdata).typeahead(
@@ -1857,8 +1858,7 @@ console.log(fobject);
           p.guid = guid();
           rt.propertyTemplates.push(p);
         });
-        console.log(rt);
-        getForm(bfeditor.bfestore.loadtemplates);
+        cbLoadTemplates(rt.propertyTemplates);       
       });
       $addproplabel = $('<label class="col-sm-3 control-label">Add Property</label>');
       $addprop = $('<div>', { class: 'form-group row' });
@@ -2096,7 +2096,7 @@ console.log(fobject);
 
     if (propsdata[0] === undefined) {
       // log the resulttry again
-      console.log(property.propertyURI + ' not matched.');
+      // console.log(property.propertyURI + ' not matched.');
     }
     if (propsdata[0] !== undefined) {
       // If this property exists for this resource in the pre-loaded data

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -684,6 +684,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
                   bfestore.created = rowData.created;
                   bfestore.url = rowData.url;
                   bfestore.profile = rowData.profile;
+                  bfestore.addedproperties = rowData.addedproperties;
                   $('[href=#create]').tab('show');
                   if ($('#bfeditor-messagediv').length) {
                     $('#bfeditor-messagediv').remove();
@@ -1248,7 +1249,11 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
               }
 
               save_json.rdf = bfeditor.bfestore.store2jsonldExpanded();
-              save_json.addedproperties = addedProperties;
+              addedProperties.forEach(function(addprops) {
+                bfeditor.bfestore.addedproperties.push(addprops);
+              });
+              save_json.addedproperties = bfeditor.bfestore.addedproperties;
+              
 
               if (_.some(bfeditor.bfestore.store, {'p': 'http://id.loc.gov/ontologies/bibframe/mainTitle'})) {
                 editorconfig.save.callback(save_json, editorconfig.getCSRF.callback(), bfelog, function (save, save_name) {
@@ -1370,7 +1375,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
     var spnums = spid.replace('sp-', '').split('_');
     var spoints = editorconfig.startingPoints[spnums[0]].menuItems[spnums[1]];
     addedProperties = [];
-    
+
     bfeditor.bfestore.store = [];
     bfeditor.bfestore.name = guid();
     bfeditor.bfestore.created = new Date().toUTCString();
@@ -1633,7 +1638,12 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       $resourceinput.append($saves);
       $resourcediv.append($formgroup);
       var addPropsUsed = {};
-
+      if (bfeditor.bfestore.addedproperties !== undefined && rt.embedType == 'page' && !pt) {
+        bfeditor.bfestore.addedproperties.forEach(function(adata) {
+          rt.propertyTemplates.push(adata);
+        });
+      }
+      console.log(rt);
       rt.propertyTemplates.forEach(function (property) {
         // Each property needs to be uniquely identified, separate from
         // the resourceTemplate.

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -1878,15 +1878,20 @@ var substringMatcher = function(strs) {
     // contains the substring `q`, add it to the `matches` array
     $.each(strs, function(i, str) {
       if (substrRegex.test(str.id)) {
-        matches.push(str.id);
+        matches.push({value: str.id});
       }
     });
     console.log(matches);
     cb(matches);
   };
 };
+
       $addpropinput = $('<input>', { type: 'text', id: 'add-property', class: 'typeahead' });
-      $addpropinput.typeahead(null,
+      $addpropinput.typeahead(
+        {
+          hint: true,
+          suggestions: true
+        },
         {
           name: 'resources',
           displayKey: 'value',

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -1122,7 +1122,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       if (loadtemplates.length > 0) {
         bfelog.addMsg(new Error(), 'DEBUG', 'Loading selected template(s)', loadtemplates);
         var form = getForm(loadtemplates);
-        $('.typeahead:not(#add-property)', form.form).each(function () {
+        $('.typeahead:not("#add-property")', form.form).each(function () {
           setTypeahead(this);
         });
         var $exitButtonGroup = $('<div class="btn-group pull-right"> \
@@ -1880,15 +1880,15 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       };
       
       $addpropdata = $('<div>', { class: 'col-sm-8' });
-      $('<input>').appendTo($addpropdata).typeahead(
+      $('<input>', { id: 'add-property' }).appendTo($addpropdata).typeahead(
         {
-          hint: true,
-          limit: 5
+          highlight: true,
         },
         {
           name: 'resources',
           displayKey: 'value',
-          source: substringMatcher(resourceTemplates)
+          source: substringMatcher(resourceTemplates),
+          limit: 5
         }
       );
       $addproplabel = $('<label class="col-sm-3 control-label">Add Property</label>');

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -1122,7 +1122,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       if (loadtemplates.length > 0) {
         bfelog.addMsg(new Error(), 'DEBUG', 'Loading selected template(s)', loadtemplates);
         var form = getForm(loadtemplates);
-        $('.typeahead.form-control', form.form).each(function () {
+        $('.typeahead', form.form).each(function () {
           setTypeahead(this);
         });
         var $exitButtonGroup = $('<div class="btn-group pull-right"> \
@@ -1880,7 +1880,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       };
       
       $addpropdata = $('<div>', { class: 'col-sm-8' });
-      $addpropinput = $('<input>', { id: 'addproperty', type: 'text', class: 'typeahead', style: 'width: 100%' });
+      $addpropinput = $('<input>', { id: 'addproperty', type: 'text', class: 'form-control' });
       $addpropinput.appendTo($addpropdata).typeahead(
         {
           highlight: true,        
@@ -2752,7 +2752,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       $(this).empty();
     });
 
-    $('.typeahead.form-control', form.form).each(function () {
+    $('.typeahead', form.form).each(function () {
       setTypeahead(this);
     });
 

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -1632,7 +1632,31 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       // $button.append($linkbutton);
       // $formgroup.append($button);
       $resourcediv.append($formgroup);
-
+      console.log(resourceTemplates);
+      /* rt.propertyTemplates.push({
+        "mandatory": "false",
+        "repeatable": "true",
+        "type": "resource",
+        "resourceTemplates": [],
+        "valueConstraint": {
+          "valueTemplateRefs": [],
+          "useValuesFrom": [
+            "http://id.loc.gov/vocabulary/contentTypes"
+          ],
+          "valueDataType": {
+            "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+          },
+          "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
+          "defaultLiteral": "text",
+          "editable": "false",
+          "repeatable": "true"
+        },
+        "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+        "propertyLabel": "Add Field...",
+        "remark": "",
+        "guid": "b5b847d5-be28-4ee6-a9cc-8f3d4c4ba61c",
+        "display": "true"
+      }); */
       rt.propertyTemplates.forEach(function (property) {
         // Each property needs to be uniquely identified, separate from
         // the resourceTemplate.
@@ -1839,23 +1863,48 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
         $resourcediv.append($formgroup);
         forEachFirst = false;
       });
+      
+var substringMatcher = function(strs) {
+  return function findMatches(q, cb) {
+    var matches, substrRegex;
 
+    // an array that will be populated with substring matches
+    matches = [];
+
+    // regex used to determine if a string contains the substring `q`
+    substrRegex = new RegExp(q, 'i');
+
+    // iterate through the pool of strings and for any string that
+    // contains the substring `q`, add it to the `matches` array
+    $.each(strs, function(i, str) {
+      if (substrRegex.test(str.id)) {
+        matches.push(str.id);
+      }
+    });
+    console.log(matches);
+    cb(matches);
+  };
+};
       $addpropinput = $('<input>', { type: 'text', id: 'add-property', class: 'typeahead' });
-      $addpropinput.typeahead({
-        hint: true,
-        minLength: 1,
-        source: ['homer','marge','bart','lisa']
-      });
-
+      $addpropinput.typeahead(null,
+        {
+          name: 'resources',
+          displayKey: 'value',
+          templates: { header: '<div>Hey</div>' },
+          source: substringMatcher(resourceTemplates)
+        }
+      );
       $addpropdata = $('<div>', { class: 'col-sm-8' });
-      $addpropdata.append($addpropinput);
+      $addpropspan = $('<span>', {class: 'twitter-typeahead' });
+      $addpropspan.append($addpropinput);
+      $addpropdata.append($addpropspan);
       $addproplabel = $('<label class="col-sm-3 control-label">Add Property</label>');
       $addprop = $('<div>', { class: 'form-group row' });
       $addprop.append($addproplabel);
       $addprop.append($addpropdata);
-
       $resourcediv.append($addprop);
       form.append($resourcediv);
+      
     });
 
     // OK now we need to populate the form with data, if appropriate.
@@ -3104,6 +3153,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       };
       dshash.displayKey = 'value';
       dshashes.push(dshash);
+      console.log(dshash);
     });
 
     bfelog.addMsg(new Error(), 'DEBUG', 'Data source hashes', dshashes);

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -659,7 +659,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
                         if (findRt[0] !== undefined){
                             spoints = _.where(editorconfig.startingPoints, { menuItems:[{type:bTypes}] })[0].menuItems[0];
                         }
-  */
+              */
               var temptemplates = [];
               spoints.useResourceTemplates.forEach(function (l) {
                 var useguid = guid();
@@ -1183,7 +1183,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
                          <button id="bfeditor-exitback" type="button" class="btn btn-default">&#9664;</button> \
                          <button id="bfeditor-exitcancel" type="button" class="btn btn-default">Cancel</button> \
                          <button id="bfeditor-exitsave" type="button" class="btn btn-primary">Save</button> \
-   <button id="bfeditor-exitpublish" type="button" class="btn btn-danger">Post</button> \
+                         <button id="bfeditor-exitpublish" type="button" class="btn btn-danger">Post</button> \
                          </div>');
 
           var $bfeditor = $('#create > .row');
@@ -1195,8 +1195,8 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
                          <div class="panel-collapse collapse in" id="jsonld"><div class="panel-body"><pre>' + JSON.stringify(jsonstr, undefined, ' ') + '</pre></div></div>\
                          <div class="panel panel-default"><div class="panel-heading"><h3 class="panel-title"><a role="button" data-toggle="collapse" href="#rdfxml">RDF-XML</a></h3></div>\
                          <div class="panel-collapse collapse in" id="rdfxml"><div class="panel-body"><pre></pre></div></div>\
-   <div class="panel panel-default"><div class="panel-heading"><h3 class="panel-title"><a role="button" data-toggle="collapse" href="#jsonld-vis">Visualize</a></h3</div></div>\
-   <div class="panel-collapse collapse in" id="jsonld-vis"><div class="panel-body"></div></div></div>\
+                         <div class="panel panel-default"><div class="panel-heading"><h3 class="panel-title"><a role="button" data-toggle="collapse" href="#jsonld-vis">Visualize</a></h3</div></div>\
+                         <div class="panel-collapse collapse in" id="jsonld-vis"><div class="panel-body"></div></div></div>\
                          </div>');
           var $messagediv;
           $bfeditor.append($saveButtonGroup);

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -1864,45 +1864,33 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
         forEachFirst = false;
       });
       
-var substringMatcher = function(strs) {
-  return function findMatches(q, cb) {
-    var matches, substrRegex;
-
-    // an array that will be populated with substring matches
-    matches = [];
-
-    // regex used to determine if a string contains the substring `q`
-    substrRegex = new RegExp(q, 'i');
-
-    // iterate through the pool of strings and for any string that
-    // contains the substring `q`, add it to the `matches` array
-    $.each(strs, function(i, str) {
-      if (substrRegex.test(str.id)) {
-        matches.push({value: str.id});
-      }
-    });
-    console.log(matches);
-    cb(matches);
-  };
-};
-
-      $addpropinput = $('<input>', { type: 'text', id: 'add-property', class: 'typeahead' });
-      $addpropinput.typeahead(
+      var substringMatcher = function(strs) {
+        return function findMatches(q, cb) {
+          var matches, substrRegex;
+          matches = [];
+          substrRegex = new RegExp(q, 'i');
+          $.each(strs, function(i, str) {
+            if (substrRegex.test(str.id)) {
+              matches.push({value: str.id});
+            }
+          });
+          console.log(matches);
+          cb(matches);
+        };
+      };
+      
+      $addpropdata = $('<div>', { class: 'col-sm-8' });
+      $('<input>').appendTo($addpropdata).typeahead(
         {
           hint: true,
-          suggestions: true
+          limit: 5
         },
         {
           name: 'resources',
           displayKey: 'value',
-          templates: { header: '<div>Hey</div>' },
           source: substringMatcher(resourceTemplates)
         }
       );
-      $addpropdata = $('<div>', { class: 'col-sm-8' });
-      $addpropspan = $('<span>', {class: 'twitter-typeahead' });
-      $addpropspan.append($addpropinput);
-      $addpropdata.append($addpropspan);
       $addproplabel = $('<label class="col-sm-3 control-label">Add Property</label>');
       $addprop = $('<div>', { class: 'form-group row' });
       $addprop.append($addproplabel);


### PR DESCRIPTION
Ok, this was a very complex ordeal, but I believe that adding a new property is working decently.  Here's a list of changes:

* Added "add property" to the bottom of the form.  It is a typeahead function.
* The suggestions are populated with properties found in all profiles in verso.
* These properties have a type of "literal" or "lookup".
* Properties already included in the loaded profile will not be included in the list, as well as previously added  properties (ie. it is impossible to add duplicate properties.)
* Upon selection the new input box will appear above the "added property" row, the added properties are also staged to be saved in verso.
* After clicking "preview" and "save" an "addedproperties" field will be added to verso and will contain an array of properties added.
* When reloading a record with added properites, the added properties will appear in the form.  (Note: there is currently no way to delete an added property which I suppose should be on my TODO list.)