### PR TITLE
Load records metaproxy

### DIFF
--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -940,23 +940,25 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
 
     $tabcontentdiv.find('#bfeditor-loaduri, #bfeditor-loadmarc').click(function () {
       var spoints = {};
-      
+
       if (this.id == 'bfeditor-loadmarc') {
         var spid = $(this.parentElement).find('#bfeditor-loadmarc-dropdownMenu').val();
         var spnums = spid.replace('sp-', '').split('_'); 
         spoints = editorconfig.startingPoints[spnums[0]].menuItems[spnums[1]];
+        bfeditor.bfestore.state = 'loadmarc';
       } else {
         spoints = { label: 'Loaded Work',
           type: ['http://id.loc.gov/ontologies/bibframe/Work'],
           useResourceTemplates: ['profile:bf2:Monograph:Work']
         };
+        bfeditor.bfestore.state = 'loaduri';
       }
  
       bfeditor.bfestore.store = [];
       bfeditor.bfestore.name = guid();
       bfeditor.bfestore.created = new Date().toUTCString();
       bfeditor.bfestore.url = config.url + '/verso/api/bfs?filter=%7B%22name%22%3A%20%22' + bfeditor.bfestore.name + '%22%7D';
-      bfeditor.bfestore.state = 'loaduri';
+      // bfeditor.bfestore.state = 'loaduri';
       bfeditor.bfestore.profile = spoints.useResourceTemplates[0];
       loadtemplatesCount = spoints.useResourceTemplates.length;
 

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -3727,12 +3727,14 @@ bfe.define('src/bfestore', ['require', 'exports', 'module'], function (require, 
       url: url,
       success: function (data) {
         bfestore.store = bfestore.jsonldcompacted2store(data, function(expanded) {
-          expanded.forEach(function (nnode) {
-            nnode['@id'] = nnode['@id'].replace(/^_:N/, '_:bnode');
-          });
           console.log(expanded);
           bfestore.store = [];
           tempstore = bfestore.jsonld2store(expanded);
+          tempstore.forEach(function (nnode) {
+            nnode.s = nnode.s.replace(/^_:N/, '_:bnode');
+            nnode.o = nnode.o.replace(/^_:N/, '_:bnode');
+          });
+          console.log(tempstore);
           callback(loadtemplates);
         });
       },

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -2098,9 +2098,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
   }
 
   function preloadData (property, rt, form, fobject) {
-    console.log(rt.defaulturi);
-    console.log(property.propertyURI);
-    console.log('-------');
+
     var propsdata = _.where(bfestore.store, {
       's': rt.defaulturi,
       'p': property.propertyURI
@@ -3743,15 +3741,15 @@ bfe.define('src/bfestore', ['require', 'exports', 'module'], function (require, 
           tempstore.forEach(function (nnode) {
             nnode.s = nnode.s.replace(/^_:N/, '_:bnode');
             nnode.s = nnode.s.replace(/bibframe.example.org\/(\d+)#Work/, 'id.loc.gov/resources/works/c' + '$1'.padStart(7, 0));
-            nnode.s = nnode.s.replace(/bibframe.example.org\/(\d+)#Instance/, 'id.loc.gov/resources/instances/c' + '$1'.padStart(7, 0));
-            nnode.s = nnode.s.replace(/bibframe.example.org\/(\d+)#Item.*/, 'id.loc.gov/resources/items/c' + '$1'.padStart(7, 0));
+            nnode.s = nnode.s.replace(/bibframe.example.org\/(\d+)#Instance/, 'id.loc.gov/resources/instances/c' + '$1'.padStart(7, 0) + '0001');
+            nnode.s = nnode.s.replace(/bibframe.example.org\/(\d+)#Item.*/, 'id.loc.gov/resources/items/c' + '$1'.padStart(7, 0) + '0001');
             if (nnode.o !== undefined) {
               nnode.o = nnode.o.replace(/^_:N/, '_:bnode');
               nnode.o = nnode.o.replace(/bibframe.example.org\/(\d+)#Work/, 'id.loc.gov/resources/works/c' + '$1'.padStart(7, 0));
-              nnode.o = nnode.o.replace(/bibframe.example.org\/(\d+)#Instance/, 'id.loc.gov/resources/instances/c' + '$1'.padStart(7, 0));
-              // nnode.o = nnode.o.replace(/bibframe.example.org\/(\d+)#Item.*$/, 'id.loc.gov/resources/items/c' + '$1'.padStart(7, 0));
+              nnode.o = nnode.o.replace(/bibframe.example.org\/(\d+)#Instance/, 'id.loc.gov/resources/instances/c' + '$1'.padStart(7, 0) + '0001');
+              nnode.o = nnode.o.replace(/bibframe.example.org\/(\d+)#Item.*$/, 'id.loc.gov/resources/items/c' + '$1'.padStart(7, 0) + '0001');
             } 
-            // console.log(nnode);
+            console.log(nnode);
           });
           callback(loadtemplates);
         });

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -974,16 +974,27 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
     $loadmarcdiv.append($('<div class="container"> \
             <form role="form" method="get"> \
             <div class="form-group"> \
-            <label for="bibid">Bib ID or LCCN</label> \
+            <label for="marcdx">Bib ID or LCCN</label> \
+            <div class="input-group"> \
+            <div class="input-group-btn"> \
+            <button type="button" id="marcdx" class="btn btn-default dropdown-toggle" data-toggle="dropdown">Index <span class="caret"></span></button> \
+            <ul class="dropdown-menu"> \
+            <li><a href="#" id="bibid">Bib ID</a></li> \
+            <li><a href="#" id="lccn">LCCN</a></li> \
+            </ul></div> \
             <input id="bfeditor-loadmarcterm" class="form-control" placeholder="Enter Bib ID or LCCN" type="text" name="url" id="url"> \
-            <div class="radio-group"><label class="radio-inline"><input type="radio" name="index" checked>Bib ID</label> \
-            <label class="radio-inline"><input type="radio" name="index">LCCN</label></div> \
+            </div> \
             <label for="bfeditor-loadmarc-dropdown">Choose Profile</label> \
             <div id="bfeditor-loadmarc-dropdown" class="dropdown"><select id="bfeditor-loadmarc-dropdownMenu" type="select" class="form-control">Select Profile</select></div></div> \
             <button id="bfeditor-loadmarc" type="button" class="btn btn-primary">Submit</button> \
             </form></div>'));
     
     getProfileOptions($loadmarcdiv.find('#bfeditor-loadmarc-dropdownMenu'));
+    
+    $loadmarcdiv.find('.dropdown-menu > li > a').click(function() {
+      console.log($(this));
+      $('#marcdx').html($(this).text() + ' <span class="caret">');
+    });
     
     $tabcontentdiv.append($browsediv);
     $tabcontentdiv.append($creatediv);

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -3724,7 +3724,7 @@ bfe.define('src/bfestore', ['require', 'exports', 'module'], function (require, 
 
   exports.store = [];
 
-  exports.rdfxml2store = function (rdf, loadtemplates, callback) {
+  exports.rdfxml2store = function (rdf, loadtemplates, recid, callback) {
     var url = 'http://rdf-translator.appspot.com/convert/xml/json-ld/content';
     var bfestore = this;
 
@@ -3740,14 +3740,14 @@ bfe.define('src/bfestore', ['require', 'exports', 'module'], function (require, 
           tempstore = bfestore.jsonld2store(expanded);
           tempstore.forEach(function (nnode) {
             nnode.s = nnode.s.replace(/^_:N/, '_:bnode');
-            nnode.s = nnode.s.replace(/bibframe.example.org\/(\d+)#Work/, 'id.loc.gov/resources/works/c' + '$1'.padStart(7, 0));
-            nnode.s = nnode.s.replace(/bibframe.example.org\/(\d+)#Instance/, 'id.loc.gov/resources/instances/c' + '$1'.padStart(7, 0) + '0001');
-            nnode.s = nnode.s.replace(/bibframe.example.org\/(\d+)#Item.*/, 'id.loc.gov/resources/items/c' + '$1'.padStart(7, 0) + '0001');
+            nnode.s = nnode.s.replace(/bibframe.example.org\/.+#(Work|Topic).*/, 'id.loc.gov/resources/works/c' + recid);
+            nnode.s = nnode.s.replace(/bibframe.example.org\/.+#Instance.*/, 'id.loc.gov/resources/instances/c' + recid + '0001');
+            nnode.s = nnode.s.replace(/bibframe.example.org\/.+#Item.*/, 'id.loc.gov/resources/items/c' + recid + '0001');
             if (nnode.o !== undefined) {
               nnode.o = nnode.o.replace(/^_:N/, '_:bnode');
-              nnode.o = nnode.o.replace(/bibframe.example.org\/(\d+)#Work/, 'id.loc.gov/resources/works/c' + '$1'.padStart(7, 0));
-              nnode.o = nnode.o.replace(/bibframe.example.org\/(\d+)#Instance/, 'id.loc.gov/resources/instances/c' + '$1'.padStart(7, 0) + '0001');
-              nnode.o = nnode.o.replace(/bibframe.example.org\/(\d+)#Item.*$/, 'id.loc.gov/resources/items/c' + '$1'.padStart(7, 0) + '0001');
+              nnode.o = nnode.o.replace(/bibframe.example.org\/.+#(Work|Topic).*/, 'id.loc.gov/resources/works/c' + recid);
+              nnode.o = nnode.o.replace(/bibframe.example.org\/.+#Instance.*/, 'id.loc.gov/resources/instances/c' + recid + '0001');
+              nnode.o = nnode.o.replace(/bibframe.example.org\/.+#Item.*/, 'id.loc.gov/resources/items/c' + recid + '0001');
             } 
             console.log(nnode);
           });

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -3716,10 +3716,9 @@ bfe.define('src/bfestore', ['require', 'exports', 'module'], function (require, 
 
   exports.store = [];
 
-  exports.rdfTranslate = function (rdf, from, to) {
-
-    var url = 'http://rdf-translator.appspot.com/convert/' + from + '/' + to + '/content';
-
+  exports.rdfxml2store = function (rdf, loadtemplates, callback) {
+    var url = 'http://rdf-translator.appspot.com/convert/xml/json-ld/content';
+    var bfestore = this;
     $.ajax({
       contentType: 'application/x-www-form-urlencoded',
       type: "POST",
@@ -3727,7 +3726,11 @@ bfe.define('src/bfestore', ['require', 'exports', 'module'], function (require, 
       data: { content: rdf},
       url: url,
       success: function (data) {
-        console.log(data);
+        bfestore.store = bfestore.jsonldcompacted2store(data, function(expanded) {
+          bfestore.store = [];
+          tempstore = bfestore.jsonld2store(expanded);
+          callback(loadtemplates);
+        });
       },
       error: function(XMLHttpRequest, textStatus, errorThrown) { 
         bfelog.addMsg(new Error(), "ERROR", "FAILED to load external source: " + url);

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -3729,7 +3729,7 @@ bfe.define('src/bfestore', ['require', 'exports', 'module'], function (require, 
   exports.rdfxml2store = function (rdf, loadtemplates, callback) {
     var url = 'http://rdf-translator.appspot.com/convert/xml/json-ld/content';
     var bfestore = this;
-    console.log(loadtemplates);
+
     $.ajax({
       contentType: 'application/x-www-form-urlencoded',
       type: "POST",
@@ -3742,16 +3742,16 @@ bfe.define('src/bfestore', ['require', 'exports', 'module'], function (require, 
           tempstore = bfestore.jsonld2store(expanded);
           tempstore.forEach(function (nnode) {
             nnode.s = nnode.s.replace(/^_:N/, '_:bnode');
-            nnode.s = nnode.s.replace(/bibframe.example.org\/(\d+)#Work/, 'id.loc.gov/resources/works/$1');
-            nnode.s = nnode.s.replace(/bibframe.example.org\/(\d+)#Instance/, 'id.loc.gov/resources/instances/$1');
-            nnode.s = nnode.s.replace(/bibframe.example.org\/(\d+)#Item.*/, 'id.loc.gov/resources/items/$1');
+            nnode.s = nnode.s.replace(/bibframe.example.org\/(\d+)#Work/, 'id.loc.gov/resources/works/c' + '$1'.padStart(7, 0));
+            nnode.s = nnode.s.replace(/bibframe.example.org\/(\d+)#Instance/, 'id.loc.gov/resources/instances/c' + '$1'.padStart(7, 0));
+            nnode.s = nnode.s.replace(/bibframe.example.org\/(\d+)#Item.*/, 'id.loc.gov/resources/items/c' + '$1'.padStart(7, 0));
             if (nnode.o !== undefined) {
               nnode.o = nnode.o.replace(/^_:N/, '_:bnode');
-              nnode.o = nnode.o.replace(/bibframe.example.org\/(\d+)#Work/, 'id.loc.gov/resources/works/$1');
-              nnode.o = nnode.o.replace(/bibframe.example.org\/(\d+)#Instance/, 'id.loc.gov/resources/instances/$1');
-              nnode.o = nnode.o.replace(/bibframe.example.org\/(\d+)#Item.*/, 'id.loc.gov/resources/items/$1');
-            }
-            console.log(nnode);
+              nnode.o = nnode.o.replace(/bibframe.example.org\/(\d+)#Work/, 'id.loc.gov/resources/works/c' + '$1'.padStart(7, 0));
+              nnode.o = nnode.o.replace(/bibframe.example.org\/(\d+)#Instance/, 'id.loc.gov/resources/instances/c' + '$1'.padStart(7, 0));
+              // nnode.o = nnode.o.replace(/bibframe.example.org\/(\d+)#Item.*$/, 'id.loc.gov/resources/items/c' + '$1'.padStart(7, 0));
+            } 
+            // console.log(nnode);
           });
           callback(loadtemplates);
         });

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -970,7 +970,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
           bfestore.loadtemplates = temptemplates;
           var url = $(this.parentElement).find('#bfeditor-loaduriInput, #loadmarc-uri').val();
           editorconfig.retrieve.callback(url, bfestore, bfestore.loadtemplates, bfelog, function (loadtemplates) {
-            console.log(this);
+            console.log(loadtemplates);
             // converter uses bf:person intead of personal name
             _.each(_.where(bfeditor.bfestore.store, {'p': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'o': 'http://id.loc.gov/ontologies/bibframe/Person'}), function (triple) {
               triple.o = 'http://www.loc.gov/mads/rdf/v1#PersonalName';
@@ -3727,6 +3727,10 @@ bfe.define('src/bfestore', ['require', 'exports', 'module'], function (require, 
       url: url,
       success: function (data) {
         bfestore.store = bfestore.jsonldcompacted2store(data, function(expanded) {
+          expanded.forEach(function (nnode) {
+            nnode['@id'] = nnode['@id'].replace(/^_:N/, '_:bnode');
+          });
+          console.log(expanded);
           bfestore.store = [];
           tempstore = bfestore.jsonld2store(expanded);
           callback(loadtemplates);

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -3716,6 +3716,26 @@ bfe.define('src/bfestore', ['require', 'exports', 'module'], function (require, 
 
   exports.store = [];
 
+  exports.rdfTranslate = function (rdf, from, to) {
+
+    var url = 'http://rdf-translator.appspot.com/convert/' + from + '/' + to + '/content';
+
+    $.ajax({
+      contentType: 'application/x-www-form-urlencoded',
+      type: "POST",
+      async: false,
+      data: { content: rdf},
+      url: url,
+      success: function (data) {
+        console.log(data);
+      },
+      error: function(XMLHttpRequest, textStatus, errorThrown) { 
+        bfelog.addMsg(new Error(), "ERROR", "FAILED to load external source: " + url);
+        bfelog.addMsg(new Error(), "ERROR", "Request status: " + textStatus + "; Error msg: " + errorThrown);
+      }
+    });
+  }
+
   exports.addTriple = function (triple) {
     exports.store.push(triple);
     if (triple.rtid !== undefined) { exports.n3store.addTriple(triple.s, triple.p, triple.o, triple.rtID); } else { exports.n3store.addTriple(triple.s, triple.p, triple.o); }

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -946,6 +946,11 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
         useResourceTemplates: ['profile:bf2:Monograph:Work']
       };
 
+     /* spoints = { label: 'Loaded Instance',
+        type: ['http://id.loc.gov/ontologies/bibframe/Instance'],
+        useResourceTemplates: ['profile:bf2:Monograph:Instance']
+      }; */
+
       bfeditor.bfestore.store = [];
       bfeditor.bfestore.name = guid();
       bfeditor.bfestore.created = new Date().toUTCString();
@@ -970,7 +975,6 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
           bfestore.loadtemplates = temptemplates;
           var url = $(this.parentElement).find('#bfeditor-loaduriInput, #loadmarc-uri').val();
           editorconfig.retrieve.callback(url, bfestore, bfestore.loadtemplates, bfelog, function (loadtemplates) {
-            console.log(loadtemplates);
             // converter uses bf:person intead of personal name
             _.each(_.where(bfeditor.bfestore.store, {'p': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'o': 'http://id.loc.gov/ontologies/bibframe/Person'}), function (triple) {
               triple.o = 'http://www.loc.gov/mads/rdf/v1#PersonalName';
@@ -2091,6 +2095,9 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
   }
 
   function preloadData (property, rt, form, fobject) {
+    console.log(rt.defaulturi);
+    console.log(property.propertyURI);
+    console.log('-------');
     var propsdata = _.where(bfestore.store, {
       's': rt.defaulturi,
       'p': property.propertyURI
@@ -3719,6 +3726,7 @@ bfe.define('src/bfestore', ['require', 'exports', 'module'], function (require, 
   exports.rdfxml2store = function (rdf, loadtemplates, callback) {
     var url = 'http://rdf-translator.appspot.com/convert/xml/json-ld/content';
     var bfestore = this;
+    console.log(loadtemplates);
     $.ajax({
       contentType: 'application/x-www-form-urlencoded',
       type: "POST",
@@ -3731,9 +3739,16 @@ bfe.define('src/bfestore', ['require', 'exports', 'module'], function (require, 
           tempstore = bfestore.jsonld2store(expanded);
           tempstore.forEach(function (nnode) {
             nnode.s = nnode.s.replace(/^_:N/, '_:bnode');
+            nnode.s = nnode.s.replace(/bibframe.example.org\/(\d+)#Work/, 'id.loc.gov/resources/works/$1');
+            nnode.s = nnode.s.replace(/bibframe.example.org\/(\d+)#Instance/, 'id.loc.gov/resources/instances/$1');
+            nnode.s = nnode.s.replace(/bibframe.example.org\/(\d+)#Item.*/, 'id.loc.gov/resources/items/$1');
             if (nnode.o !== undefined) {
               nnode.o = nnode.o.replace(/^_:N/, '_:bnode');
+              nnode.o = nnode.o.replace(/bibframe.example.org\/(\d+)#Work/, 'id.loc.gov/resources/works/$1');
+              nnode.o = nnode.o.replace(/bibframe.example.org\/(\d+)#Instance/, 'id.loc.gov/resources/instances/$1');
+              nnode.o = nnode.o.replace(/bibframe.example.org\/(\d+)#Item.*/, 'id.loc.gov/resources/items/$1');
             }
+            console.log(nnode);
           });
           callback(loadtemplates);
         });

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -994,6 +994,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
     $loadmarcdiv.find('.dropdown-menu > li > a').click(function() {
       console.log($(this));
       $('#marcdx').html($(this).text() + ' <span class="caret">');
+      $('#marcdx').attr('value', $(this).attr('id'));
     });
     
     $tabcontentdiv.append($browsediv);

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -939,18 +939,19 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
     $tabcontentdiv.append($loadmarcdiv);
 
     $tabcontentdiv.find('#bfeditor-loaduri, #bfeditor-loadmarc').click(function () {
-      // var loadtemplates = [];
-
-      var spoints = { label: 'Loaded Work',
-        type: ['http://id.loc.gov/ontologies/bibframe/Work'],
-        useResourceTemplates: ['profile:bf2:Monograph:Work']
-      };
-
-     /* spoints = { label: 'Loaded Instance',
-        type: ['http://id.loc.gov/ontologies/bibframe/Instance'],
-        useResourceTemplates: ['profile:bf2:Monograph:Instance']
-      }; */
-
+      var spoints = {};
+      
+      if (this.id == 'bfeditor-loadmarc') {
+        var spid = $(this.parentElement).find('#bfeditor-loadmarc-dropdownMenu').val();
+        var spnums = spid.replace('sp-', '').split('_'); 
+        spoints = editorconfig.startingPoints[spnums[0]].menuItems[spnums[1]];
+      } else {
+        spoints = { label: 'Loaded Work',
+          type: ['http://id.loc.gov/ontologies/bibframe/Work'],
+          useResourceTemplates: ['profile:bf2:Monograph:Work']
+        };
+      }
+ 
       bfeditor.bfestore.store = [];
       bfeditor.bfestore.name = guid();
       bfeditor.bfestore.created = new Date().toUTCString();

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -821,6 +821,24 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       }
     });
 
+    var getProfileOptions = function(jqObject) {
+      for (var h = 0; h < config.startingPoints.length; h++) {
+        var sp = config.startingPoints[h];
+        var label = sp.menuGroup
+        for (var i = 0; i < sp.menuItems.length; i++) {
+          var $option = $('<option>', {
+            class: 'dropdown-item',
+            value: 'sp-' + h + '_' + i
+          });
+          if(sp.menuItems[i].type[0] === "http://id.loc.gov/ontologies/bibframe/Instance" || sp.menuItems[i].type[0] === "http://id.loc.gov/ontologies/bibframe/Serial"){
+            //$a.html(sp.menuItems[i].label);
+            $option.html(label);
+            jqObject.append($option);
+          }
+        }      
+      }
+    }
+
     var $loadibcform = $('<div class="container"> \
             <form role="form" method="get"> \
             <div class="form-group"> \
@@ -829,25 +847,9 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
             <div id="bfeditor-loadibc-dropdown" class="dropdown"><select id="bfeditor-loadibc-dropdownMenu" type="select" class="form-control">Select Profile</select> \
             </div></div> \
             <button id="bfeditor-loadibcuri" type="button" class="btn btn-primary">Submit URL</button> \
-            </form></div>')
+            </form></div>');
 
-    var $ibcmenudiv = $loadibcform.find('#bfeditor-loadibc-dropdownMenu');
-
-    for (var h = 0; h < config.startingPoints.length; h++) {
-          var sp = config.startingPoints[h];
-          var label = sp.menuGroup
-          for (var i = 0; i < sp.menuItems.length; i++) {
-            var $option = $('<option>', {
-              class: 'dropdown-item',
-              value: 'sp-' + h + '_' + i
-            });
-            if(sp.menuItems[i].type[0] === "http://id.loc.gov/ontologies/bibframe/Instance" || sp.menuItems[i].type[0] === "http://id.loc.gov/ontologies/bibframe/Serial"){
-              //$a.html(sp.menuItems[i].label);
-              $option.html(label);
-              $ibcmenudiv.append($option);
-            }
-          }      
-        }
+    getProfileOptions($loadibcform.find('#bfeditor-loadibc-dropdownMenu'));
 
     $loadibcdiv.append($loadibcform);
             
@@ -974,11 +976,15 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
             <div class="form-group"> \
             <label for="bibid">Bib ID or LCCN</label> \
             <input id="bfeditor-loadmarcterm" class="form-control" placeholder="Enter Bib ID or LCCN" type="text" name="url" id="url"> \
-            <label class="radio-inline"><input type="radio" name="bibid" checked>Bib ID</label> \
-            <label class="radio-inline"><input type="radio" name="lccn">LCCN</label></div> \
+            <div class="radio-group"><label class="radio-inline"><input type="radio" name="index" checked>Bib ID</label> \
+            <label class="radio-inline"><input type="radio" name="index">LCCN</label></div> \
+            <label for="bfeditor-loadmarc-dropdown">Choose Profile</label> \
+            <div id="bfeditor-loadmarc-dropdown" class="dropdown"><select id="bfeditor-loadmarc-dropdownMenu" type="select" class="form-control">Select Profile</select></div></div> \
             <button id="bfeditor-loadmarc" type="button" class="btn btn-primary">Submit</button> \
             </form></div>'));
-
+    
+    getProfileOptions($loadmarcdiv.find('#bfeditor-loadmarc-dropdownMenu'));
+    
     $tabcontentdiv.append($browsediv);
     $tabcontentdiv.append($creatediv);
     $tabcontentdiv.append($loaddiv);

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -905,7 +905,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
             <label for="marcdx">Bib ID or LCCN</label> \
             <div class="input-group"> \
             <div class="input-group-btn"> \
-            <button type="button" id="marcdx" class="btn btn-default dropdown-toggle" data-toggle="dropdown">Index <span class="caret"></span></button> \
+            <button type="button" id="marcdx" class="btn btn-default dropdown-toggle" data-toggle="dropdown">Bib ID <span class="caret"></span></button> \
             <ul class="dropdown-menu"> \
             <li><a href="#" id="bibid">Bib ID</a></li> \
             <li><a href="#" id="lccn">LCCN</a></li> \

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -938,7 +938,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
     $tabcontentdiv.append($loadibcdiv);
     $tabcontentdiv.append($loadmarcdiv);
 
-    $tabcontentdiv.find('#bfeditor-loaduri, #bfeditor-loadmarcxx').click(function () {
+    $tabcontentdiv.find('#bfeditor-loaduri, #bfeditor-loadmarc').click(function () {
       // var loadtemplates = [];
 
       var spoints = { label: 'Loaded Work',
@@ -968,8 +968,9 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       if (editorconfig.retrieve.callback !== undefined) {
         try {
           bfestore.loadtemplates = temptemplates;
-          var url = $(this.parentElement).find('#bfeditor-loaduriInput').val();
+          var url = $(this.parentElement).find('#bfeditor-loaduriInput, #loadmarc-uri').val();
           editorconfig.retrieve.callback(url, bfestore, bfestore.loadtemplates, bfelog, function (loadtemplates) {
+            console.log(this);
             // converter uses bf:person intead of personal name
             _.each(_.where(bfeditor.bfestore.store, {'p': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'o': 'http://id.loc.gov/ontologies/bibframe/Person'}), function (triple) {
               triple.o = 'http://www.loc.gov/mads/rdf/v1#PersonalName';

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -385,6 +385,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
     $tabul.append('<li><a data-toggle="tab" href="#create">Editor</a></li>');
     $tabul.append('<li><a data-toggle="tab" href="#load">Load Work</a></li>');
     $tabul.append('<li><a data-toggle="tab" href="#loadibc">Load IBC</a></li>');
+    $tabul.append('<li><a data-toggle="tab" href="#loadmarc">Load MARC</a></li>');
 
     $tabuldiv.append($tabul);
     $containerdiv.append($tabuldiv);
@@ -394,6 +395,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
     var $creatediv = $('<div id="create" class="tab-pane fade"><br></div>');
     var $loaddiv = $('<div id="load" class="tab-pane fade"><br></div>');
     var $loadibcdiv = $('<div id="loadibc" class="tab-pane fade"><br></div>');
+    var $loadmarcdiv = $('<div id="loadmarc" class="tab-pane fade"><br></div>');
 
     var $menudiv = $('<div>', {
       id: 'bfeditor-menudiv',
@@ -967,10 +969,21 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
       }
     });
 
+    $loadmarcdiv.append($('<div class="container"> \
+            <form role="form" method="get"> \
+            <div class="form-group"> \
+            <label for="bibid">Bib ID or LCCN</label> \
+            <input id="bfeditor-loadmarcterm" class="form-control" placeholder="Enter Bib ID or LCCN" type="text" name="url" id="url"> \
+            <label class="radio-inline"><input type="radio" name="bibid" checked>Bib ID</label> \
+            <label class="radio-inline"><input type="radio" name="lccn">LCCN</label></div> \
+            <button id="bfeditor-loadmarc" type="button" class="btn btn-primary">Submit</button> \
+            </form></div>'));
+
     $tabcontentdiv.append($browsediv);
     $tabcontentdiv.append($creatediv);
     $tabcontentdiv.append($loaddiv);
     $tabcontentdiv.append($loadibcdiv);
+    $tabcontentdiv.append($loadmarcdiv);
 
     $containerdiv.append($tabcontentdiv);
 

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -998,7 +998,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
 
             // weird bnode prob
             _.each(bfeditor.bfestore.store, function (el) {
-              if (el.o.startsWith('_:_:')) { el.o = '_:' + el.o.split('_:')[2]; }
+              if (el.o !== undefined && el.o.startsWith('_:_:')) { el.o = '_:' + el.o.split('_:')[2]; }
             });
 
             cbLoadTemplates();
@@ -3727,14 +3727,14 @@ bfe.define('src/bfestore', ['require', 'exports', 'module'], function (require, 
       url: url,
       success: function (data) {
         bfestore.store = bfestore.jsonldcompacted2store(data, function(expanded) {
-          console.log(expanded);
           bfestore.store = [];
           tempstore = bfestore.jsonld2store(expanded);
           tempstore.forEach(function (nnode) {
             nnode.s = nnode.s.replace(/^_:N/, '_:bnode');
-            nnode.o = nnode.o.replace(/^_:N/, '_:bnode');
+            if (nnode.o !== undefined) {
+              nnode.o = nnode.o.replace(/^_:N/, '_:bnode');
+            }
           });
-          console.log(tempstore);
           callback(loadtemplates);
         });
       },

--- a/static/js/config-dev.js
+++ b/static/js/config-dev.js
@@ -139,9 +139,10 @@ function publish(data, rdfxml, savename, bfelog, callback){
 
 
 function retrieve(uri, bfestore, loadtemplates, bfelog, callback){
+  var $messagediv = $('<div>', {id: "bfeditor-messagediv", class:"col-md-10 main"});
   var url = config.url + "/profile-edit/server/whichrt";
   var dType = (bfestore.state == 'loadmarc') ? 'xml' : 'json';
-
+  console.log(dType);
   $.ajax({
     dataType: dType,
     type: "GET",
@@ -153,8 +154,14 @@ function retrieve(uri, bfestore, loadtemplates, bfelog, callback){
       bfelog.addMsg(new Error(), "DEBUG", "Source data", data);
       
       if (dType == 'xml') {
-        var rdfrec  = $('zs\\:recordData', data).html();
-        bfestore.rdfxml2store(rdfrec, loadtemplates, callback);
+        var recCount = $('zs\\:numberOfRecords', data).text();
+        if (recCount != '0') {
+          var rdfrec  = $('zs\\:recordData', data).html();
+          bfestore.rdfxml2store(rdfrec, loadtemplates, callback);
+        } else {
+          $messagediv.append('<div class="alert alert-danger alert-dismissible"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times; </a><strong>No records found! </strong>(' + uri + ')</div>');
+          $messagediv.insertAfter('#loadmarc .container');
+        }
       } else {
         bfestore.store = bfestore.jsonldcompacted2store(data, function(expanded) {
           bfestore.store = [];
@@ -233,7 +240,7 @@ function deleteId(id, csrf, bfelog){
 var rectoBase = "http://mlvlp04.loc.gov:3000";
 
 // The following line is for local developement
-// rectoBase = "http://localhost:3000";
+rectoBase = "http://localhost:3000";
 var versoURL = rectoBase + "/verso/api";
 
 var config = {

--- a/static/js/config-dev.js
+++ b/static/js/config-dev.js
@@ -139,9 +139,8 @@ function publish(data, rdfxml, savename, bfelog, callback){
 
 
 function retrieve(uri, bfestore, loadtemplates, bfelog, callback){
-  console.log(loadtemplates);
   var url = config.url + "/profile-edit/server/whichrt";
-  var dType = !uri.match(/jsonld$/) ? 'xml' : 'json';
+  var dType = (bfestore.state == 'loadmarc') ? 'xml' : 'json';
   
   $.ajax({
     dataType: dType,
@@ -150,7 +149,7 @@ function retrieve(uri, bfestore, loadtemplates, bfelog, callback){
     data: { uri: uri},
     url: url,
     success: function (data) {
-      bfelog.addMsg(new Error(), "INFO", "Fetched external source baseURI" + url);
+      bfelog.addMsg(new Error(), "INFO", "Fetched external source baseURI " + uri);
       bfelog.addMsg(new Error(), "DEBUG", "Source data", data);
       
       if (dType == 'xml') {
@@ -234,14 +233,14 @@ function deleteId(id, csrf, bfelog){
 var rectoBase = "http://mlvlp04.loc.gov:3000";
 
 // The following line is for local developement
-// rectoBase = "http://localhost:3000";
+rectoBase = "http://localhost:3000";
 var versoURL = rectoBase + "/verso/api";
 
 var config = {
-              /* "logging": {
+              "logging": {
                 "level": "DEBUG",
                 "toConsole": false
-              }, */
+              },
   "url" : rectoBase,
   "baseURI": "http://id.loc.gov/",
   "basedbURI": "http://mlvlp04.loc.gov:8230",

--- a/static/js/config-dev.js
+++ b/static/js/config-dev.js
@@ -142,7 +142,7 @@ function retrieve(uri, bfestore, loadtemplates, bfelog, callback){
   var $messagediv = $('<div>', {id: "bfeditor-messagediv", class:"col-md-10 main"});
   var url = config.url + "/profile-edit/server/whichrt";
   var dType = (bfestore.state == 'loadmarc') ? 'xml' : 'json';
-  console.log(dType);
+
   $.ajax({
     dataType: dType,
     type: "GET",
@@ -159,7 +159,6 @@ function retrieve(uri, bfestore, loadtemplates, bfelog, callback){
           var rdfrec  = $('zs\\:recordData', data).html();
           var recid = $('bf\\:Local > rdf\\:value', data).html()
           recid = recid.padStart(9, '0');
-          console.log(recid);
           bfestore.rdfxml2store(rdfrec, loadtemplates, recid, callback);
         } else {
           var q = uri.replace(/.+query=(.+?)&.+/, "$1");
@@ -167,8 +166,6 @@ function retrieve(uri, bfestore, loadtemplates, bfelog, callback){
           <div class="modal-header">No Record Found!</div><div class="modal-body"><p>Query: "' + q + '"</p></div> \
           <div class="modal-footer"><button type="button" class="btn btn-primary" data-dismiss="modal">OK</button></div></div></div></div>');
           $nohits.modal('show');
-          /* $('body').append($nohits);
-          $('#nohits').modal('show'); */
         }
       } else {
         bfestore.store = bfestore.jsonldcompacted2store(data, function(expanded) {

--- a/static/js/config-dev.js
+++ b/static/js/config-dev.js
@@ -141,7 +141,7 @@ function publish(data, rdfxml, savename, bfelog, callback){
 function retrieve(uri, bfestore, loadtemplates, bfelog, callback){
   var url = config.url + "/profile-edit/server/whichrt";
   var dType = (bfestore.state == 'loadmarc') ? 'xml' : 'json';
-  
+
   $.ajax({
     dataType: dType,
     type: "GET",
@@ -233,14 +233,14 @@ function deleteId(id, csrf, bfelog){
 var rectoBase = "http://mlvlp04.loc.gov:3000";
 
 // The following line is for local developement
-rectoBase = "http://localhost:3000";
+// rectoBase = "http://localhost:3000";
 var versoURL = rectoBase + "/verso/api";
 
 var config = {
-              "logging": {
+              /* "logging": {
                 "level": "DEBUG",
                 "toConsole": false
-              },
+              }, */
   "url" : rectoBase,
   "baseURI": "http://id.loc.gov/",
   "basedbURI": "http://mlvlp04.loc.gov:8230",

--- a/static/js/config-dev.js
+++ b/static/js/config-dev.js
@@ -159,8 +159,13 @@ function retrieve(uri, bfestore, loadtemplates, bfelog, callback){
           var rdfrec  = $('zs\\:recordData', data).html();
           bfestore.rdfxml2store(rdfrec, loadtemplates, callback);
         } else {
-          $messagediv.append('<div class="alert alert-danger alert-dismissible"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times; </a><strong>No records found! </strong>(' + uri + ')</div>');
-          $messagediv.insertAfter('#loadmarc .container');
+          var q = uri.replace(/.+query=(.+?)&.+/, "$1");
+          $nohits = $('<div class="modal" tabindex="-1" role="dialog" id="nohits"><div class="modal-dialog" role="document"><div class="modal-content"> \
+          <div class="modal-header">No Record Found!</div><div class="modal-body"><p>Query: "' + q + '"</p></div> \
+          <div class="modal-footer"><button type="button" class="btn btn-primary" data-dismiss="modal">OK</button></div></div></div></div>');
+          $nohits.modal('show');
+          /* $('body').append($nohits);
+          $('#nohits').modal('show'); */
         }
       } else {
         bfestore.store = bfestore.jsonldcompacted2store(data, function(expanded) {
@@ -240,7 +245,7 @@ function deleteId(id, csrf, bfelog){
 var rectoBase = "http://mlvlp04.loc.gov:3000";
 
 // The following line is for local developement
-rectoBase = "http://localhost:3000";
+// rectoBase = "http://localhost:3000";
 var versoURL = rectoBase + "/verso/api";
 
 var config = {

--- a/static/js/config-dev.js
+++ b/static/js/config-dev.js
@@ -157,7 +157,10 @@ function retrieve(uri, bfestore, loadtemplates, bfelog, callback){
         var recCount = $('zs\\:numberOfRecords', data).text();
         if (recCount != '0') {
           var rdfrec  = $('zs\\:recordData', data).html();
-          bfestore.rdfxml2store(rdfrec, loadtemplates, callback);
+          var recid = $('bf\\:Local > rdf\\:value', data).html()
+          recid = recid.padStart(9, '0');
+          console.log(recid);
+          bfestore.rdfxml2store(rdfrec, loadtemplates, recid, callback);
         } else {
           var q = uri.replace(/.+query=(.+?)&.+/, "$1");
           $nohits = $('<div class="modal" tabindex="-1" role="dialog" id="nohits"><div class="modal-dialog" role="document"><div class="modal-content"> \


### PR DESCRIPTION
I think this is ready for prime time.   Here are some bullet points:

1) In the UI, you'll find a "Load MARC" tab.
2) The user may choose from searching by Bib ID or LCCN by clicking the dropdown.
3) The user can change profiles by using the "Choose profile" dropdown (this uses the same function as Load IBC)
4) An SRU request is made to lx2.loc.gov:210 with recordSchema set to "bibfram2a" and will retrieve a single record.  NOTE: if a record is not found a modal pops up alerting the user.
5) The RDF portion of the response is posted to http://rdf-translator.appspot.com/ which returns a JSON-LD record.  This all happens in a function named rdfxml2store.
6) The response is added to bfestore.store using jsonldcompacted2store.
7) The stored object is then updated to change URIs (i.e. http://bibframe.example.org) to something the editor can use (i.e. http://id.loc.gov).  This function also adds a 9 digit, 0 padded Bib id to the URIs.
8) Instance and Item URIs get "0001" appended to them so that they can be found at http://mlvlp04.loc.gov:8230/resources/instances/...

Enjoy!