### PR TITLE
Lookup by identifier

### DIFF
--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -3185,7 +3185,8 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
         header: '<h3>' + lu.name + '</h3>',
         footer: '<div id="dropdown-footer" class=".col-sm-1"></div>'
       };
-      dshash.displayKey = (dshash.name.match(/^LCNAF|^LCSH/)) ? 'display' : 'value';
+      // dshash.displayKey = (dshash.name.match(/^LCNAF|^LCSH/)) ? 'display' : 'value';
+      dshash.displayKey = 'display';
       dshashes.push(dshash);
     });
 
@@ -4287,9 +4288,6 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
           dataType: 'jsonp',
           success: function (data) {
             parsedlist = lcshared.processSuggestions(data, query);
-            parsedlist.forEach(function (item) {
-              item.display = (item.uri) ? item.value + ' (' + item.uri.replace(/^.+\//, "") + ')' : item.value;
-            });
             cache[q] = parsedlist;
             return process(parsedlist);
           }
@@ -4301,9 +4299,6 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
           dataType: 'jsonp',
           success: function (data) {
             parsedlist = lcshared.processATOM(data, query);
-            parsedlist.forEach(function (item) {
-              item.display = (item.uri) ? item.value + ' (' + item.uri.replace(/^.+\//, "") + ')' : item.value;
-            });
             cache[q] = parsedlist;
             return process(parsedlist);
           }
@@ -4436,6 +4431,8 @@ bfe.define('src/lookups/lcshared', ['require', 'exports', 'module'], function (r
       for (var s = 0; s < suggestions[1].length; s++) {
         var l = suggestions[1][s];
         var u = suggestions[3][s];
+        var id = u.replace(/.+\/(.+)/, '$1');
+        var d = l + ' (' + id + ')';
         if (suggestions.length === 5) {
           var i = suggestions[4][s];
           var li = l + ' (' + i + ')';
@@ -4445,14 +4442,15 @@ bfe.define('src/lookups/lcshared', ['require', 'exports', 'module'], function (r
 
         typeahead_source.push({
           uri: u,
-          value: li
+          value: li,
+          display: d
         });
       }
     }
     if (typeahead_source.length === 0) {
       typeahead_source[0] = {
         uri: '',
-        value: '[No suggestions found for ' + query + '.]'
+        display: '[No suggestions found for ' + query + '.]'
       };
     }
     // console.log(typeahead_source);
@@ -4467,6 +4465,7 @@ bfe.define('src/lookups/lcshared', ['require', 'exports', 'module'], function (r
         var t = '';
         var u = '';
         var source = '';
+        var d = '';
         for (var e in atomjson[k]) {
           if (atomjson[k][e][0] == 'atom:title') {
             t = atomjson[k][e][2];
@@ -4474,22 +4473,26 @@ bfe.define('src/lookups/lcshared', ['require', 'exports', 'module'], function (r
           if (atomjson[k][e][0] == 'atom:link') {
             u = atomjson[k][e][1].href;
             source = u.substr(0, u.lastIndexOf('/'));
+            var id = u.replace(/.+\/(.+)/, '$1');
+            d = t + ' (' + id + ')';
           }
           if (t !== '' && u !== '') {
             typeahead_source.push({
               uri: u,
               source: source,
-              value: t
+              value: t, 
+              display: d
             });
             break;
           }
+          console.log(typeahead_source);
         }
       }
     }
     if (typeahead_source.length === 0) {
       typeahead_source[0] = {
         uri: '',
-        value: '[No suggestions found for ' + query + '.]'
+        display: '[No suggestions found for ' + query + '.]'
       };
     }
     // console.log(typeahead_source);
@@ -4622,9 +4625,6 @@ bfe.define('src/lookups/lcsubjects', ['require', 'exports', 'module', 'src/looku
           dataType: 'jsonp',
           success: function (data) {
             parsedlist = lcshared.processSuggestions(data, query);
-            parsedlist.forEach(function (item) {
-              item.display = (item.uri) ? item.value + ' (' + item.uri.replace(/^.+\//, "") + ')' : item.value;
-            });
             cache[q] = parsedlist;
             return process(parsedlist);
           }
@@ -4636,9 +4636,6 @@ bfe.define('src/lookups/lcsubjects', ['require', 'exports', 'module', 'src/looku
           dataType: 'jsonp',
           success: function (data) {
             parsedlist = lcshared.processATOM(data, query);
-            parsedlist.forEach(function (item) {
-              item.display = (item.uri) ? item.value + ' (' + item.uri.replace(/^.+\//, "") + ')' : item.value;
-            });
             cache[q] = parsedlist;
             return process(parsedlist);
           }
@@ -4694,7 +4691,7 @@ bfe.define('src/lookups/lcgenreforms', ['require', 'exports', 'module', 'src/loo
     }
     // lcgft
     this.searching = setTimeout(function () {
-      if (query.length > 2) {
+      if (query.length > 2 && !query.match(/[Gg][A-z]?\d/)) {
         suggestquery = query;
         if (rdftype !== '') { suggestquery += '&rdftype=' + rdftype.replace('rdftype:', ''); }
 
@@ -4711,7 +4708,18 @@ bfe.define('src/lookups/lcgenreforms', ['require', 'exports', 'module', 'src/loo
           }
 
         });
-      } else {
+      } /* else if (query.length > 2 && query.match(/[Gg][A-z]?\d/)) {
+        u = 'http://id.loc.gov/search/?q=cs:http://id.loc.gov/authorities/genreForms%20AND%20(' + query + ')&start=1&format=atom';
+        $.ajax({
+          url: u,
+          dataType: 'jsonp',
+          success: function (data) {
+            parsedlist = lcshared.processATOM(data, query);
+            cache[q] = parsedlist;
+            return process(parsedlist);
+          }
+        });
+      } */ else {
         return [];
       }
     }, 300); // 300 ms

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -4275,13 +4275,13 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
     }
 
     this.searching = setTimeout(function () {
-      if (query.length > 2 && query.substr(0, 1) != '?') {
+      if (query.length > 2 && query.substr(0, 1) != '?' && !query.substr(2, 1).match(/\d/)) {
         suggestquery = query.normalize();
+        console.log(query);
         if (rdftype !== '') { suggestquery += '&rdftype=' + rdftype.replace('rdftype:', ''); }
 
         u = exports.scheme + '/suggest/?q=' + suggestquery + '&count=50';
 
-        // u = exports.scheme + "/suggest/?q=" + query;
         $.ajax({
           url: u,
           dataType: 'jsonp',

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -4290,7 +4290,6 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
             parsedlist.forEach(function (item) {
               item.display = item.value + ' (' + item.uri.replace(/^.+\//, "") + ')';
             });
-            console.log(parsedlist);
             cache[q] = parsedlist;
             return process(parsedlist);
           }
@@ -4302,6 +4301,9 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
           dataType: 'jsonp',
           success: function (data) {
             parsedlist = lcshared.processATOM(data, query);
+            parsedlist.forEach(function (item) {
+              item.display = item.value + ' (' + item.uri.replace(/^.+\//, "") + ')';
+            });
             cache[q] = parsedlist;
             return process(parsedlist);
           }

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -3185,7 +3185,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
         header: '<h3>' + lu.name + '</h3>',
         footer: '<div id="dropdown-footer" class=".col-sm-1"></div>'
       };
-      dshash.displayKey = (dshash.name == 'LCNAF') ? 'display' : 'value';
+      dshash.displayKey = (dshash.name.match(/^LCNAF|^LCSH/)) ? 'display' : 'value';
       dshashes.push(dshash);
     });
 
@@ -4275,7 +4275,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
     }
 
     this.searching = setTimeout(function () {
-      if (query.length > 2 && query.substr(0, 1) != '?' && !query.substr(1, 2).match(/\d/)) {
+      if (query.length > 2 && query.substr(0, 1) != '?' && !query.match(/^[Nn][A-z]{0,1}\d/)) {
         suggestquery = query.normalize();
         console.log(query);
         if (rdftype !== '') { suggestquery += '&rdftype=' + rdftype.replace('rdftype:', ''); }
@@ -4612,7 +4612,7 @@ bfe.define('src/lookups/lcsubjects', ['require', 'exports', 'module', 'src/looku
     }
 
     this.searching = setTimeout(function () {
-      if (query.length > 2 && query.substr(0, 1) != '?') {
+      if (query.length > 2 && query.substr(0, 1) != '?' && !query.match(/[Ss][A-z]{0,1}\d/)) {
         suggestquery = query.normalize();
         if (rdftype !== '') { suggestquery += '&rdftype=' + rdftype.replace('rdftype:', ''); }
 
@@ -4622,6 +4622,9 @@ bfe.define('src/lookups/lcsubjects', ['require', 'exports', 'module', 'src/looku
           dataType: 'jsonp',
           success: function (data) {
             parsedlist = lcshared.processSuggestions(data, query);
+            parsedlist.forEach(function (item) {
+              item.display = item.value + ' (' + item.uri.replace(/^.+\//, "") + ')';
+            });
             cache[q] = parsedlist;
             return process(parsedlist);
           }
@@ -4633,6 +4636,9 @@ bfe.define('src/lookups/lcsubjects', ['require', 'exports', 'module', 'src/looku
           dataType: 'jsonp',
           success: function (data) {
             parsedlist = lcshared.processATOM(data, query);
+            parsedlist.forEach(function (item) {
+              item.display = item.value + ' (' + item.uri.replace(/^.+\//, "") + ')';
+            });
             cache[q] = parsedlist;
             return process(parsedlist);
           }

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -3185,7 +3185,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
         header: '<h3>' + lu.name + '</h3>',
         footer: '<div id="dropdown-footer" class=".col-sm-1"></div>'
       };
-      dshash.displayKey = 'value';
+      dshash.displayKey = (dshash.name == 'LCNAF') ? 'display' : 'value';
       dshashes.push(dshash);
     });
 
@@ -4275,7 +4275,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
     }
 
     this.searching = setTimeout(function () {
-      if (query.length > 2 && query.substr(0, 1) != '?' && !query.substr(2, 1).match(/\d/)) {
+      if (query.length > 2 && query.substr(0, 1) != '?' && !query.substr(1, 2).match(/\d/)) {
         suggestquery = query.normalize();
         console.log(query);
         if (rdftype !== '') { suggestquery += '&rdftype=' + rdftype.replace('rdftype:', ''); }
@@ -4287,6 +4287,10 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
           dataType: 'jsonp',
           success: function (data) {
             parsedlist = lcshared.processSuggestions(data, query);
+            parsedlist.forEach(function (item) {
+              item.display = item.value + ' (' + item.uri.replace(/^.+\//, "") + ')';
+            });
+            console.log(parsedlist);
             cache[q] = parsedlist;
             return process(parsedlist);
           }

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -4288,7 +4288,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
           success: function (data) {
             parsedlist = lcshared.processSuggestions(data, query);
             parsedlist.forEach(function (item) {
-              item.display = item.value + ' (' + item.uri.replace(/^.+\//, "") + ')';
+              item.display = (item.uri) ? item.value + ' (' + item.uri.replace(/^.+\//, "") + ')' : item.value;
             });
             cache[q] = parsedlist;
             return process(parsedlist);
@@ -4302,7 +4302,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
           success: function (data) {
             parsedlist = lcshared.processATOM(data, query);
             parsedlist.forEach(function (item) {
-              item.display = item.value + ' (' + item.uri.replace(/^.+\//, "") + ')';
+              item.display = (item.uri) ? item.value + ' (' + item.uri.replace(/^.+\//, "") + ')' : item.value;
             });
             cache[q] = parsedlist;
             return process(parsedlist);
@@ -4623,7 +4623,7 @@ bfe.define('src/lookups/lcsubjects', ['require', 'exports', 'module', 'src/looku
           success: function (data) {
             parsedlist = lcshared.processSuggestions(data, query);
             parsedlist.forEach(function (item) {
-              item.display = item.value + ' (' + item.uri.replace(/^.+\//, "") + ')';
+              item.display = (item.uri) ? item.value + ' (' + item.uri.replace(/^.+\//, "") + ')' : item.value;
             });
             cache[q] = parsedlist;
             return process(parsedlist);
@@ -4637,7 +4637,7 @@ bfe.define('src/lookups/lcsubjects', ['require', 'exports', 'module', 'src/looku
           success: function (data) {
             parsedlist = lcshared.processATOM(data, query);
             parsedlist.forEach(function (item) {
-              item.display = item.value + ' (' + item.uri.replace(/^.+\//, "") + ')';
+              item.display = (item.uri) ? item.value + ' (' + item.uri.replace(/^.+\//, "") + ')' : item.value;
             });
             cache[q] = parsedlist;
             return process(parsedlist);


### PR DESCRIPTION
This may need more work (I haven't checked all lookups.)  However, looking up names and subjects works nicely.  So here's the concept.

1) The IDs display in the suggestions for all lookups that use the processSuggestions or processATOM functions.
2) When clicking on the suggestion only the value populates the form (no ID in parenthesis.)  This is unlike the lookup works stuff where the IDs display and are also included in the form value-- I don't know if this is a bug or the catalogers want it in there.
3) The lookup detects an ID search if the query starts with a 'n' for names, 's' for subjects and the second character is either a letter or number or if the third character is a number.  If so, then it performs an atom search (this does not work with genre lookups because of a CORS issue.)

So, that's basically it.  

Enjoy,
--Charles