### PR TITLE
Defaults array

### DIFF
--- a/builds/bfe.css
+++ b/builds/bfe.css
@@ -1,4 +1,4 @@
-/* bfe 2015-10-26 *//*!
+/* bfe 2018-09-10 *//*!
  * Bootstrap v3.1.1 (http://getbootstrap.com)
  * Copyright 2011-2014 Twitter, Inc.
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
@@ -4210,4 +4210,8 @@ button.close {
 
 div#save-btn{
     margin-bottom:10px;
+}
+
+input[pattern]:invalid {
+  color: red;
 }

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -2332,6 +2332,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
         for (d = 0; d < property.valueConstraint.defaults.length; d++) {
           if (!_.isEmpty(property.valueConstraint.defaults[d].defaultURI) || !_.isEmpty(property.valueConstraint.defaults[d].defaultLiteral)) {
             var data;
+            var label;
             if (property.type === "literal"){
                 //the default is the literal
                 var literalTriple = {};
@@ -2344,7 +2345,8 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
                 literalTriple.p = property.propertyURI;
                 literalTriple.o = property.valueConstraint.defaults[d].defaultLiteral;
                 literalTriple.otype = 'literal';
-                
+                label = literalTriple;
+                displayguid = literalTriple.guid;
                 fobject.store.push(literalTriple);
                 bfestore.addTriple(literalTriple);
 
@@ -2379,7 +2381,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
               bfestore.addTriple(triple);
             
               // set the label
-                var label = {};
+                label = {};
                 if (triple) {
                   label.s = triple.o;
                   displayguid = triple.guid;

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -2305,98 +2305,113 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
         });
       }
     } else if (_.has(property, 'valueConstraint')) {
-      //(!_.isEmpty(property.valueConstraint.defaultURI) || !_.isEmpty(property.valueConstraint.defaultLiteral))) {
-      // Otherwise - if the property is not found in the pre-loaded data
-      // then do we have a default value?
-      var data;
-      if (_.has(property.valueConstraint, 'defaultURI') && !_.isEmpty(property.valueConstraint.defaultURI)) {
-        data = property.valueConstraint.defaultURI;
-      }
 
-      if (data) {
-        bfelog.addMsg(new Error(), 'DEBUG', 'Setting default data for ' + property.propertyURI);
-
-        // is there a type?
-        if (_.has(property.valueConstraint.valueDataType, 'dataTypeURI')) {
-          var typeTriple = {};
-          typeTriple.guid = guid();
-          typeTriple.s = data;
-          typeTriple.p = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'; // rdf:type
-          typeTriple.o = property.valueConstraint.valueDataType.dataTypeURI;
-          typeTriple.otype = 'uri';
-          fobject.store.push(typeTriple);
-          // bfestore.addTriple(typeTriple);
+        // we need to convert defaults from the old "defaults" model to the new.
+        if (!_.has(property.valueConstraint, 'defaults')) {
+          property.valueConstraint.defaults = [];
+          var defaultsObj = {};
+          if (!_.isEmpty(property.valueConstraint.defaultURI)) {
+            defaultsObj.defaultURI = property.valueConstraint.defaultURI;
+          }
+          if (!_.isEmpty(property.valueConstraint.defaultLiteral)) {
+            defaultsObj.defaultLiteral = property.valueConstraint.defaultLiteral;
+          }
+          if (!_.isEmpty(defaultsObj)) {
+            property.valueConstraint.defaults.push(defaultsObj);
+          }
+        }
+        
+        // Otherwise - if the property is not found in the pre-loaded data
+        // then do we have a default value?
+        var data;
+        if (_.has(property.valueConstraint, 'defaultURI') && !_.isEmpty(property.valueConstraint.defaultURI)) {
+          data = property.valueConstraint.defaultURI;
         }
 
-        data = property.valueConstraint.defaultURI;
-        // set the triples
-        var triple = {};
-        triple.guid = guid();
-        if (rt.defaulturi !== undefined && rt.defaulturi !== '') {
-          triple.s = rt.defaulturi;
+        if (data) {
+          bfelog.addMsg(new Error(), 'DEBUG', 'Setting default data for ' + property.propertyURI);
+
+          // is there a type?
+          if (_.has(property.valueConstraint.valueDataType, 'dataTypeURI')) {
+            var typeTriple = {};
+            typeTriple.guid = guid();
+            typeTriple.s = data;
+            typeTriple.p = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'; // rdf:type
+            typeTriple.o = property.valueConstraint.valueDataType.dataTypeURI;
+            typeTriple.otype = 'uri';
+            fobject.store.push(typeTriple);
+            // bfestore.addTriple(typeTriple);
+          }
+
+          data = property.valueConstraint.defaultURI;
+          // set the triples
+          var triple = {};
+          triple.guid = guid();
+          if (rt.defaulturi !== undefined && rt.defaulturi !== '') {
+            triple.s = rt.defaulturi;
+          } else {
+            triple.s = editorconfig.baseURI + rt.useguid;
+          }
+          triple.p = property.propertyURI;
+          triple.o = data;
+          triple.otype = 'uri';
+          fobject.store.push(triple);
+          //                bfestore.addTriple(triple);
+        }
+        // set the label
+        var label = {};
+        if (triple) {
+          label.s = triple.o;
+          displayguid = triple.guid;
         } else {
-          triple.s = editorconfig.baseURI + rt.useguid;
+          label.s = rt.defaulturi;
+          displayguid = guid();
         }
-        triple.p = property.propertyURI;
-        triple.o = data;
-        triple.otype = 'uri';
-        fobject.store.push(triple);
-        //                bfestore.addTriple(triple);
-      }
-      // set the label
-      var label = {};
-      if (triple) {
-        label.s = triple.o;
-        displayguid = triple.guid;
-      } else {
-        label.s = rt.defaulturi;
-        displayguid = guid();
-      }
 
-      label.otype = 'literal';
-      label.p = 'http://www.w3.org/2000/01/rdf-schema#label';
-      label.o = property.valueConstraint.defaultLiteral;
+        label.otype = 'literal';
+        label.p = 'http://www.w3.org/2000/01/rdf-schema#label';
+        label.o = property.valueConstraint.defaultLiteral;
 
-      fobject.store.push(label);
-      // bfestore.addTriple(label);
+        fobject.store.push(label);
+        // bfestore.addTriple(label);
 
-      // set the form
-      var $formgroup = $('#' + property.guid, form).closest('.form-group');
-      var $save = $formgroup.find('.btn-toolbar').eq(0);
+        // set the form
+        var $formgroup = $('#' + property.guid, form).closest('.form-group');
+        var $save = $formgroup.find('.btn-toolbar').eq(0);
 
-      var displaydata = '';
-      if (_.has(property.valueConstraint, 'defaultLiteral')) {
-        displaydata = property.valueConstraint.defaultLiteral;
-      }
-      // displaydata = display;
-      var editable = true;
-      if (property.valueConstraint.editable !== undefined && property.valueConstraint.editable === 'false') {
-        editable = false;
-      }
-      var bgvars = {
-        'tguid': displayguid,
-        'tlabelhover': displaydata,
-        'tlabel': displaydata,
-        'fobjectid': fobject.id,
-        'inputid': property.guid,
-        'editable': editable,
-        'triples': [label]
-      };
-      var $buttongroup = editDeleteButtonGroup(bgvars);
-      $save.append($buttongroup);
-
-      if (property.repeatable === 'false' || property.valueConstraint.repeatable == 'false') {
-        var $el = $('#' + property.guid, form);
-        if ($el.is('input')) {
-          $el.prop('disabled', true);
-        } else {
-          // console.log(property.propertyLabel);
-          var $buttons = $('div.btn-group', $el).find('button');
-          $buttons.each(function () {
-            $(this).prop('disabled', true);
-          });
+        var displaydata = '';
+        if (_.has(property.valueConstraint, 'defaultLiteral')) {
+          displaydata = property.valueConstraint.defaultLiteral;
         }
-      }
+        // displaydata = display;
+        var editable = true;
+        if (property.valueConstraint.editable !== undefined && property.valueConstraint.editable === 'false') {
+          editable = false;
+        }
+        var bgvars = {
+          'tguid': displayguid,
+          'tlabelhover': displaydata,
+          'tlabel': displaydata,
+          'fobjectid': fobject.id,
+          'inputid': property.guid,
+          'editable': editable,
+          'triples': [label]
+        };
+        var $buttongroup = editDeleteButtonGroup(bgvars);
+        $save.append($buttongroup);
+
+        if (property.repeatable === 'false' || property.valueConstraint.repeatable == 'false') {
+          var $el = $('#' + property.guid, form);
+          if ($el.is('input')) {
+            $el.prop('disabled', true);
+          } else {
+            // console.log(property.propertyLabel);
+            var $buttons = $('div.btn-group', $el).find('button');
+            $buttons.each(function () {
+              $(this).prop('disabled', true);
+            });
+          }
+        }
     }
   }
 

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -2304,7 +2304,8 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
           loadPropsdata(pd, property, form, fobject);
         });
       }
-    } else if (_.has(property, 'valueConstraint') && (!_.isEmpty(property.valueConstraint.defaultURI) || !_.isEmpty(property.valueConstraint.defaultLiteral))) {
+    } else if (_.has(property, 'valueConstraint')) {
+      //(!_.isEmpty(property.valueConstraint.defaultURI) || !_.isEmpty(property.valueConstraint.defaultLiteral))) {
       // Otherwise - if the property is not found in the pre-loaded data
       // then do we have a default value?
       var data;

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -2346,7 +2346,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
                 fobject.store.push(typeTriple);
                 // bfestore.addTriple(typeTriple);
               }
-
+              
               data = property.valueConstraint.defaults[d].defaultURI;
               // set the triples
               var triple = {};
@@ -2360,7 +2360,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
               triple.o = data;
               triple.otype = 'uri';
               fobject.store.push(triple);
-              //                bfestore.addTriple(triple);
+              // bfestore.addTriple(triple);
             }
             // set the label
             var label = {};

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -2327,7 +2327,7 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
         for (d = 0; d < property.valueConstraint.defaults.length; d++) {
           if (!_.isEmpty(property.valueConstraint.defaults[d].defaultURI) || !_.isEmpty(property.valueConstraint.defaults[d].defaultLiteral)) {
             var data;
-            
+
             if (_.has(property.valueConstraint.defaults[d], 'defaultURI') && !_.isEmpty(property.valueConstraint.defaults[d].defaultURI)) {
               data = property.valueConstraint.defaults[d].defaultURI;
             }
@@ -2518,7 +2518,6 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
               }
               if (!tsearch.startsWith('_:b')) {
                 whichLabel(tsearch, function (label) {
-                  console.log(label);
                   tpreflabel = label;
                 });
               }

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -2332,12 +2332,24 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
         for (d = 0; d < property.valueConstraint.defaults.length; d++) {
           if (!_.isEmpty(property.valueConstraint.defaults[d].defaultURI) || !_.isEmpty(property.valueConstraint.defaults[d].defaultLiteral)) {
             var data;
+            if (property.type === "literal"){
+                //the default is the literal
+                var literalTriple = {};
+                literalTriple.guid = guid();
+                if (rt.defaulturi !== undefined && rt.defaulturi !== '') {
+                    literalTriple.s = rt.defaulturi;
+                } else {
+                    literalTriple.s = editorconfig.baseURI + rt.useguid;
+                }
+                literalTriple.p = property.propertyURI;
+                literalTriple.o = property.valueConstraint.defaults[d].defaultLiteral;
+                literalTriple.otype = 'literal';
+                
+                fobject.store.push(literalTriple);
+                bfestore.addTriple(literalTriple);
 
-            if (_.has(property.valueConstraint.defaults[d], 'defaultURI') && !_.isEmpty(property.valueConstraint.defaults[d].defaultURI)) {
+            } else if (_.has(property.valueConstraint.defaults[d], 'defaultURI') && !_.isEmpty(property.valueConstraint.defaults[d].defaultURI)) {
               data = property.valueConstraint.defaults[d].defaultURI;
-            }
-
-            if (data) {
               bfelog.addMsg(new Error(), 'DEBUG', 'Setting default data for ' + property.propertyURI);
 
               // is there a type?
@@ -2349,10 +2361,9 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
                 typeTriple.o = property.valueConstraint.valueDataType.dataTypeURI;
                 typeTriple.otype = 'uri';
                 fobject.store.push(typeTriple);
-                // bfestore.addTriple(typeTriple);
+                bfestore.addTriple(typeTriple);
               }
               
-              data = property.valueConstraint.defaults[d].defaultURI;
               // set the triples
               var triple = {};
               triple.guid = guid();
@@ -2365,24 +2376,24 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
               triple.o = data;
               triple.otype = 'uri';
               fobject.store.push(triple);
-              // bfestore.addTriple(triple);
-            }
-            // set the label
-            var label = {};
-            if (triple) {
-              label.s = triple.o;
-              displayguid = triple.guid;
-            } else {
-              label.s = rt.defaulturi;
-              displayguid = guid();
-            }
+              bfestore.addTriple(triple);
+            
+              // set the label
+                var label = {};
+                if (triple) {
+                  label.s = triple.o;
+                  displayguid = triple.guid;
+                } else {
+                    label.s = rt.defaulturi;
+                    displayguid = guid();
+                }
 
-            label.otype = 'literal';
-            label.p = 'http://www.w3.org/2000/01/rdf-schema#label';
-            label.o = property.valueConstraint.defaults[d].defaultLiteral;
-
-            fobject.store.push(label);
-            // bfestore.addTriple(label);
+                label.otype = 'literal';
+                label.p = 'http://www.w3.org/2000/01/rdf-schema#label';
+                label.o = property.valueConstraint.defaults[d].defaultLiteral;
+                fobject.store.push(label);
+                bfestore.addTriple(label);
+            }
 
             // set the form
             var $formgroup = $('#' + property.guid, form).closest('.form-group');

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -3038,7 +3038,6 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
 
         data.forEach(function (t) {
           callingformobject.store.push(t);
-          console.log('A');
           bfestore.addTriple(t);
           // bfestore.store.push(t);
         });

--- a/builds/bfe.dev.js
+++ b/builds/bfe.dev.js
@@ -1827,7 +1827,8 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
         var $button;
 
         if (property.type == 'literal') {
-          $input = $('<div class="col-sm-8"><input type="text" class="form-control" id="' + property.guid + '" placeholder="' + property.propertyLabel + '" tabindex="' + tabIndices++ + '"></div>');
+          var vpattern = (property.valueConstraint.validatePattern !== undefined) ? ' pattern="' + property.valueConstraint.validatePattern + '"' : '';
+          $input = $('<div class="col-sm-8"><input type="text" class="form-control" id="' + property.guid + '" placeholder="' + property.propertyLabel + '"' + vpattern + '" tabindex="' + tabIndices++ + '"></div>');
 
           $input.find('input').keyup(function (e) {
             if (e.keyCode == 54 && e.ctrlKey && e.altKey) {
@@ -1841,7 +1842,11 @@ bfe.define('src/bfe', ['require', 'exports', 'module', 'src/bfestore', 'src/bfel
           $button = $('<div class="btn-group btn-group-md span1"><button type="button" class="btn btn-default" tabindex="' + tabIndices++ + '">&#10133;</button></div>');
 
           $button.click(function () {
-            setLiteral(fobject.id, rt.useguid, property.guid);
+            if ($input.find(':invalid').length == 1) {
+              alert('Invalid Value!\nThe value should match: ' + property.valueConstraint.validatePattern);
+            } else {
+              setLiteral(fobject.id, rt.useguid, property.guid);
+            }
           });
 
           var enterHandler = function (event) {


### PR DESCRIPTION
This is the twin to the changes in the profile editor that will work with the new data model-- the new data model being defaults (defaultURI and defaultLiteral) are no longer singletons.   These two properties are combined into an object and pushed to the "defaults" array.  We now can have multiple default values.

The changes basically will create a defaults array from singletons (if available) and continue on with filling in the form using the array.  This way the update will work with both data models and all of the profiles will not need to be changed in advance.

As I pointed out earlier in an email, the lines that save the default triples to bfestore have been previously commented out.  I didn't uncomment the commented out lines, figuring this was done for a reason.  Therefore, the defaults never get stored or saved.  It will be easy enough to get this to work again in the future.